### PR TITLE
Fix classpath settings for running under cygwin

### DIFF
--- a/bin/cljsc
+++ b/bin/cljsc
@@ -12,6 +12,12 @@ for next in lib/*: closure/compiler/*: src/clj: src/cljs; do
   CLJSC_CP=$CLJSC_CP$CLOJURESCRIPT_HOME'/'$next
 done
 
+if [[ `uname` == CYGWIN* ]]; then
+    CLOJURESCRIPT_HOME=`cygpath --path --windows "$CLOJURESCRIPT_HOME"`
+    CLJSC_CP=`cygpath --path --windows "$CLJSC_CP"`
+fi
+
+
 if test $# -eq 0
 then
   echo "Usage: cljsc <file-or-dir>"

--- a/script/compile
+++ b/script/compile
@@ -1,6 +1,10 @@
 #!/bin/sh
+CLASSPATH='lib/*:src/clj:src/cljs'
+if [[ `uname` == CYGWIN* ]]; then
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+fi
 
-java -server -Xmx2G -Xms2G -Xmn256m -cp 'lib/*:src/clj:src/cljs' clojure.main - > core.js <<CLJ
+java -server -Xmx2G -Xms2G -Xmn256m -cp $CLASSPATH clojure.main - > core.js <<CLJ
 (require :reload '[cljs.compiler :as comp] '[cljs.core])
 (binding [comp/*cljs-verbose* true]
   (comp/load-file (comp/repl-env) "cljs/core.cljs"))

--- a/script/repl
+++ b/script/repl
@@ -1,3 +1,8 @@
 #!/bin/sh
-java -server -Xmx2G -Xms2G -Xmn256m -cp 'lib/*:src/clj:src/cljs' clojure.main
+CLASSPATH='lib/*:src/clj:src/cljs'
+if [[ `uname` == CYGWIN* ]]; then
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+fi
+
+java -server -Xmx2G -Xms2G -Xmn256m -cp $CLASSPATH clojure.main
 

--- a/script/repljs
+++ b/script/repljs
@@ -1,5 +1,10 @@
 #!/bin/sh
-java -server -Xmx2G -Xms2G -Xmn256m -cp 'lib/*:src/clj:src/cljs' clojure.main -e \
+CLASSPATH='lib/*:src/clj:src/cljs'
+if [[ `uname` == CYGWIN* ]]; then
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+fi
+
+java -server -Xmx2G -Xms2G -Xmn256m -cp $CLASSPATH clojure.main -e \
 "(require '[cljs.compiler :as comp])
 (def jse (comp/repl-env))
 (comp/repl jse)"


### PR DESCRIPTION
Currently all scripts are strictly for linux. To allow us poor windows users to use ClojureScript, this commit converts all classpath declarations to a windows compatible format when running under cygwin.
