### PR TITLE
reset! function sends new value twice instead of old/new

### DIFF
--- a/src/cljs/cljs/core.cljs
+++ b/src/cljs/cljs/core.cljs
@@ -2780,8 +2780,9 @@ reduces them without incurring seq initialization"
   (when-let [v (.validator a)]
     (when-not (v newval)
       (throw (js/Error. "Validator rejected reference state"))))
-  (set! (.state a) newval)
-  (-notify-watches a (.state a) newval)
+  (let [oldval (.state a)]
+    (set! (.state a) newval)
+    (-notify-watches a oldval newval))
   newval)
 
 (defn swap!


### PR DESCRIPTION
Fixed a bug where the reset! function would change atom state then use that state as old value, now saves old atom value before changing it. I only did a simple test in the REPL : 
(def x (atom "initial"))
(add-watch x ::watcher println)
(reset! x "new")

old code would print "new" "new", new code prints "initial" "new".
