### PR TITLE
Bugfix: Inequalities with multiple arguments

### DIFF
--- a/src/clj/cljs/core.clj
+++ b/src/clj/cljs/core.clj
@@ -75,27 +75,27 @@
 (defmacro <
   ([x] true)
   ([x y] (list 'js* "(~{} < ~{})" x y))
-  ([x y & more] `(< (< ~x ~y) ~@more)))
+  ([x y & more] `(and (< ~x ~y) (< ~y ~@more))))
 
 (defmacro <=
   ([x] true)
   ([x y] (list 'js* "(~{} <= ~{})" x y))
-  ([x y & more] `(<= (<= ~x ~y) ~@more)))
+  ([x y & more] `(and (<= ~x ~y) (<= ~y ~@more))))
 
 (defmacro >
   ([x] true)
   ([x y] (list 'js* "(~{} > ~{})" x y))
-  ([x y & more] `(> (> ~x ~y) ~@more)))
+  ([x y & more] `(and (> ~x ~y) (> ~y ~@more))))
 
 (defmacro >=
   ([x] true)
   ([x y] (list 'js* "(~{} >= ~{})" x y))
-  ([x y & more] `(>= (>= ~x ~y) ~@more)))
+  ([x y & more] `(and (>= ~x ~y) (>= ~y ~@more))))
 
 (defmacro ==
   ([x] true)
   ([x y] (list 'js* "(~{} === ~{})" x y))
-  ([x y & more] `(== (== ~x ~y) ~@more)))
+  ([x y & more] `(and (== ~x ~y) (== ~y ~@more))))
 
 (defmacro dec [x]
   `(- ~x 1))


### PR DESCRIPTION
Hi, I'm a clojure noob, so please forgive me if I'm doing it wrong :)

I noticed that there was a problem with inequalities with more than two arguments, like (> 2 0 1), giving the wrong answer. It seems it was [caused by this patch](https://github.com/clojure/clojurescript/commit/114b666f182b8cf25fe6e593a6260940cc5da229#src/clj/cljs/core.clj).
