### PR TITLE
ftp problems from ftp.mozilla.org - change to http?

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -34,7 +34,7 @@ echo "jar cf ./lib/goog.jar -C closure/library/closure/ goog"
 jar cf ./lib/goog.jar -C closure/library/closure/ goog
 
 echo "Fetching Rhino..."
-curl -O -s ftp://ftp.mozilla.org/pub/mozilla.org/js/rhino1_7R3.zip
+curl -O -s http://ftp.mozilla.org/pub/mozilla.org/js/rhino1_7R3.zip
 unzip -qu rhino1_7R3.zip
 echo "Copying rhino1_7R3/js.jar to lib/js.jar..."
 cp rhino1_7R3/js.jar lib/js.jar


### PR DESCRIPTION
I've been unable to download rhino from ftp.mozilla.org on a debian linux virtual machine of mine:

ryan@host:~/clojure/clojurescript$ curl -O ftp://ftp.mozilla.org/pub/mozilla.org/js/rhino1_7R3.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:03:16 --:--:--     0^C

What doesn't work:
1) curl -O ftp://ftp.mozilla.org/pub/mozilla.org/js/rhino1_7R3.zip
2) curl --ftp-pasv -O ftp://ftp.mozilla.org/pub/mozilla.org/js/rhino1_7R3.zip
3) curl --disable-epsv -O ftp://ftp.mozilla.org/pub/mozilla.org/js/rhino1_7R3.zip
and, just for grins
4) curl -P eth0 -O ftp://ftp.mozilla.org/pub/mozilla.org/js/rhino1_7R3.zip

What does work:
A) ftp from my linux vm to other hosts
B) line #1 above on a different system of mine (with different networking)

After looking at packet captures I'm still unsure as to what exactly the problem is.  I see a lot of retransmits and failure of the conversation to continue after curl attempts to transfer data in EPSV (or PASV) but only on the system/vm that's unable to download the URL.  It seems like it would have something to do with NAT / connection tracking but that doesn't make sense.  The whole point of PASV and EPSV ftp is that it's NAT-friendly, i.e. just another outbound connection.

This seems like an issue that could affect other people so I'd like to suggest the rhino URL in the bootstrap script be changed from ftp://... to http://...
