### PR TITLE
Fix setting the CLASSPATH in cljsc.bat

### DIFF
--- a/bin/cljsc.bat
+++ b/bin/cljsc.bat
@@ -1,10 +1,9 @@
-
 @echo off
 setLocal EnableDelayedExpansion
 
 if "%CLOJURESCRIPT_HOME%" == "" set CLOJURESCRIPT_HOME=%~dp0..\
 
-set CLASSPATH=%CLOJURESCRIPT_HOME%src\clj;%CLOJURESCRIPT_HOME%src\cljs"
+set CLASSPATH=%CLOJURESCRIPT_HOME%\src\clj;%CLOJURESCRIPT_HOME%\src\cljs"
 for /R "%CLOJURESCRIPT_HOME%\lib" %%a in (*.jar) do (
   set CLASSPATH=!CLASSPATH!;%%a
 )
@@ -12,7 +11,7 @@ set CLASSPATH=!CLASSPATH!"
 
 if (%1) == () (
 echo Usage: "cljsc <file-or-dir> > out.js"
-echo        "cljsc <file-or-dir> {:optimiztions :advanced} > out.js"
+echo        "cljsc <file-or-dir> {:optimizations :advanced} > out.js"
 ) else (
 java -server -cp "%CLASSPATH%" clojure.main "%CLOJURESCRIPT_HOME%\bin\cljsc.clj" %*
 )


### PR DESCRIPTION
FIX: add path separators for setting CLASSPATH
FIX: type in 'Usage' message
