### PR TITLE
Typo - Duplicate of CLJ-853, fixed in clojure branch. 

### DIFF
--- a/src/cljs/cljs/core.cljs
+++ b/src/cljs/cljs/core.cljs
@@ -2654,7 +2654,7 @@ reduces them without incurring seq initialization"
 
 (defn get-in
   "Returns the value in a nested associative structure,
-  where ks is a sequence of ke(ys. Returns nil if the key is not present,
+  where ks is a sequence of keys. Returns nil if the key is not present,
   or the not-found value if supplied."
   {:added "1.2"
    :static true}


### PR DESCRIPTION
Stumbled upon this typo on 1.3 code base, checked the clojure repo and it is fixed already. Not fixed in clojurescript, plz check and merge the changes.
