### PR TITLE
Configure travis.ci to run integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+before_install:
+  - sudo apt-get install wget -qq
+  - sudo apt-get install unzip -qq
+
+before_script:
+  - echo "Fetching V8..."
+  - git clone --branch=master --depth=1 --quiet git://github.com/v8/v8.git v8 && cd v8
+  - echo "Building V8"
+  - make dependencies
+  - make native
+  - cd ./out/native/
+  - export V8_HOME=`pwd`
+  - cd ../../../
+  - echo "Fetching Spidermonkey"
+  - wget http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-central/jsshell-linux-i686.zip
+  - unzip jsshell-linux-i686.zip -d spidermonkey
+  - cd spidermonkey
+  - export SPIDERMONKEY_HOME=`pwd`
+  - cd ../
+  - ./script/bootstrap
+
+script:
+  - ./script/test


### PR DESCRIPTION
I have being using travis.ci with bunch of other projects and it's being great to be able too see status of test run in the pull requests regardless of weather you submit a change or do a review. It would be really useful to have this for clojurescript too.

Tests do work on my fork right now:
https://travis-ci.org/Gozala/clojurescript

In addition to pulling this change github hook needs to be enabled (before the pull) to trigger tests runs on pull requests and pushes. Details on this can be found here:

http://about.travis-ci.org/docs/user/how-to-setup-and-trigger-the-hook-manually/
