### PR TITLE
Allow serving of static css, jpg, png from repl server

### DIFF
--- a/src/clj/cljs/repl/browser.clj
+++ b/src/clj/cljs/repl/browser.clj
@@ -86,6 +86,9 @@
 (server/dispatch-on :get
                     (fn [{:keys [path]} _ _] (or (= path "/")
                                                 (.endsWith path ".js")
+                                                (.endsWith path ".css")
+                                                (.endsWith path ".jpg")
+                                                (.endsWith path ".png")
                                                 (.endsWith path ".html")))
                     send-static)
 


### PR DESCRIPTION
There is need to serve the whole app from repl server, thus adding few more allowed filetypes solves the immediate problem.
The question is: is there a need to allow only few "safe" file types?
