### PR TITLE
Point bootstrap to new closure download location

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -61,7 +61,7 @@ cd ..
 echo "Fetching Google Closure compiler..."
 mkdir -p compiler
 cd compiler
-curl -O -s http://closure-compiler.googlecode.com/files/compiler-latest.zip
+curl -O -s http://dl.google.com/closure-compiler/compiler-latest.zip
 unzip -qu compiler-latest.zip
 echo "Cleaning up Google Closure compiler archive..."
 rm compiler-latest.zip


### PR DESCRIPTION
When I run `./script/bootstrap`, I get an error that closure/compiler/compiler.jar doesn't exist.  That's because closure/compiler contains only README with the following text:

```
This download link is no longer updated.
To get the most recent version of closure-compiler, please use:
http://dl.google.com/closure-compiler/compiler-latest.zip
```
