### PR TITLE
Adding dirname and filename node globals

### DIFF
--- a/src/cljs/cljs/nodejs.cljs
+++ b/src/cljs/cljs/nodejs.cljs
@@ -6,6 +6,8 @@
 ; Define namespaced references to Node's externed globals:
 (def require (js* "require"))
 (def process (js* "process"))
+(def dirname (js* "__dirname"))
+(def filename (js* "__filename"))
 
 ; Have ClojureScript print using Node's sys.print function
 (set! cljs.core/string-print (.-print (require "util")))


### PR DESCRIPTION
These globals (especially dirname) are important for the sake of
interoping with Node.js libraries which often expect an exact path to a
file.
