### PR TITLE
Add missing backslashes

### DIFF
--- a/script/repl.bat
+++ b/script/repl.bat
@@ -3,7 +3,7 @@ setLocal EnableDelayedExpansion
 
 if "%CLOJURESCRIPT_HOME%" == "" set CLOJURESCRIPT_HOME=%~dp0..\
 
-set CLASSPATH=%CLOJURESCRIPT_HOME%src\clj;%CLOJURESCRIPT_HOME%src\cljs"
+set CLASSPATH=%CLOJURESCRIPT_HOME%\src\clj;%CLOJURESCRIPT_HOME%\src\cljs"
 for /R "%CLOJURESCRIPT_HOME%\lib" %%a in (*.jar) do (
   set CLASSPATH=!CLASSPATH!;%%a
 )


### PR DESCRIPTION
Note that \lib includes backslash, and it's more or less standard on Windows to not include backslash in environment variable paths. Otherwise get errors like so -

> script\repl
> Clojure 1.5.1
> user=> (require '[cljs.repl :as repl])
> FileNotFoundException Could not locate cljs/repl__init.class or cljs/repl.clj on classpath:   clojure.lang.RT.load (RT.j
> ava:443)
> user=>
