### PR TITLE
CLJS-854: Fix for IE8  cljs.reader to read integers correctly

### DIFF
--- a/src/cljs/cljs/reader.cljs
+++ b/src/cljs/cljs/reader.cljs
@@ -112,7 +112,8 @@ nil if the end of stream has been reached")
 (defn- match-int
   [s]
   (let [groups (re-matches* int-pattern s)
-        zero (aget groups 2)]
+        ie8-fix  (aget groups 2)
+        zero     (if (= ie8-fix "") nil ie8-fix)]
     (if-not (nil? zero)
       0
       (let [a (cond


### PR DESCRIPTION
This change is made because IE8 always returns 0 when cljs.reader reads an integer.

This is caused because the matching pattern in most browsers returns nil for unmatched patterns but IE8 returns "" instead of nil
