### PR TITLE
print a warning when :externs file paths can't be found.

### DIFF
--- a/src/clj/cljs/js_deps.clj
+++ b/src/clj/cljs/js_deps.clj
@@ -57,7 +57,7 @@ If no ClassLoader is provided, RT/baseLoader is assumed."
     (when (.exists file)
       (map to-url (filter #(.endsWith ^String (.getName ^File %) ".js") (file-seq (io/file path)))))))
 
-(defn find-js-classpath 
+(defn find-js-classpath
   "Returns a seq of URLs of all JavaScript files on the classpath."
   [path]
   (->> (all-classpath-urls)
@@ -86,7 +86,9 @@ case."
   (let [file (io/file path)]
     (if (.exists file)
       (find-js-fs path)
-      (find-js-classpath path))))
+      (do
+        (println "WARNING: js resource path" path "does not exist")
+        (find-js-classpath path)))))
 
 (defn parse-js-ns
   "Given the lines from a JavaScript source file, parse the provide


### PR DESCRIPTION
Presently it can be very confusing using advanced compilation if you have made a mistake in the path name of one of your :externs files. This PR makes the compiler print a warning so you can quickly determine the cause of the broken advanced compilation output.

As a side effect, when doing a basic lein-cljsbuild a warning is always printed:

```
WARNING: js resource path closure-js/externs does not exist
```

This is because lein-cljsbuild quietly adds this extra path to your :externs listing without you knowing.