### PR TITLE
ASYNC-110: Export NodeJS functions required by goog.

### DIFF
--- a/src/cljs/cljs/nodejs.cljs
+++ b/src/cljs/cljs/nodejs.cljs
@@ -18,3 +18,9 @@
 ; Have ClojureScript print using Node's sys.print function
 (defn enable-util-print! []
   (set! *print-fn* (.-print (require "util"))))
+
+; Export NodeJS globals.
+(.exportSymbol js/goog "setTimeout" js/setTimeout)
+(.exportSymbol js/goog "clearTimeout" js/clearTimeout)
+(.exportSymbol js/goog "setInterval" js/setInterval)
+(.exportSymbol js/goog "clearInterval" js/clearInterval)


### PR DESCRIPTION
The JavaScript code generated when using core.async contains references to setTimeout. This breaks when targeting NodeJS, because setTimeout is not available in the global namespace as far as goog is concerned. Fix this using goog.exportSymbol.