### PR TITLE
Fix upstream deps when run from repl.

### DIFF
--- a/src/clj/cljs/closure.clj
+++ b/src/clj/cljs/closure.clj
@@ -909,7 +909,7 @@ should contain the source for the given namespace name."
   "returns a merged map containing all upstream dependencies defined
   by libraries on the classpath. Should be run in the main thread. If
   not, pass (java.lang.ClassLoader/getSystemClassLoader) to use the
-  system classloder."
+  system classloader."
   ([]
    (get-upstream-deps* (. (Thread/currentThread) (getContextClassLoader))))
   ([classloader]

--- a/src/clj/cljs/repl/browser.clj
+++ b/src/clj/cljs/repl/browser.clj
@@ -270,7 +270,7 @@
                   support reflection. Defaults to \"src/\".
   "
   [& {:as opts}]
-  (let [ups-deps (cljsc/get-upstream-deps)
+  (let [ups-deps (cljsc/get-upstream-deps (java.lang.ClassLoader/getSystemClassLoader))
         opts (assoc opts
                :ups-libs (:libs ups-deps)
                :ups-foreign-libs (:foreign-libs ups-deps))


### PR DESCRIPTION
I found that when running piggieback from the repl

```clojure
(defn piggieback-repl []
  (cemerick.piggieback/cljs-repl :repl-env (cljs.repl.browser/repl-env :port 9000)) )
```

get-upstream-deps doesn't find anything.

This prevents me from being able to use piggieback with Om's new cljsjs dependency on React.

Comment on get-upstream-deps says

```
Should be run in the main thread. If
  not, pass (java.lang.ClassLoader/getSystemClassLoader) to use the
  system classloader.
```

I guess the repl isn't the main thread?