### PR TITLE
Check that (.hrtime js/process) exists

### DIFF
--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -338,8 +338,9 @@
   []
   (cond
     (exists? js/performance) (.now js/performance)
-    (exists? js/process) (let [t (.hrtime js/process)]
-                           (/ (+ (* (aget t 0) 1e9) (aget t 1)) 1e6))
+    (and (exists? js/process) (exists? (aget js/process "hrtime")))
+      (let [t (.hrtime js/process)]
+        (/ (+ (* (aget t 0) 1e9) (aget t 1)) 1e6))
     :else (.getTime (js/Date.))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; arrays ;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This is to fix an issue where cljs.core.system_time is failing with react native via ambly+om.next (see screenshot):

<img width="376" alt="screen shot 2015-11-01 at 9 00 01 am" src="https://cloud.githubusercontent.com/assets/702646/10870127/c1efb56e-8077-11e5-969e-ad73fe81cb8b.png">

Temporary workaround:
`(aset js/process "hrtime" (fn [] (.getTime (js/Date.))))`

@swannodette @mfikes 