### PR TITLE
proj-deps script to set env-vars for dependencies from project.clj

### DIFF
--- a/script/proj-deps
+++ b/script/proj-deps
@@ -1,0 +1,46 @@
+#! /bin/bash
+
+function upcase() {
+    echo "$1" | tr 'a-z' 'A-Z'
+}
+
+DEPS=$(sed -e '
+/^[ \i]*:dependencies *\[/!d
+/^[ \i]*:dependencies *\[/ {
+s///
+: continue
+s/^[ \i]*//
+n
+/\]\]/s//]/
+t finish
+b continue
+: finish
+s/^[ \i]*//
+q
+}
+')
+
+DEPS=$(echo "$DEPS" | \
+sed -e '
+/\[[^/]*\/\([^ ]*\)  *\("[^"]*"\).*\]/ {
+s//\1_VER=\2/
+: dots
+s/\.\(.*=\)/_\1/
+t dots
+: hyphens
+s/-\(.*=\)/_\1/
+t hyphens
+}
+')
+
+DEPS=$(echo "$DEPS" | \
+while read line
+do
+    var=$(expr "$line" : '\(.*\)=')
+    val=$(expr "$line" : '.*\(=.*\)')
+    uvar=$(upcase "$var")
+    echo "$uvar$val"
+done
+)
+
+echo "$DEPS"


### PR DESCRIPTION
This request adds a script (_proj-deps_) to the script directory.

The script reads project.clj and extracts the :dependencies as a series of shell env-var assignments.

The scripts for building and testing clojurescript have the version numbers of dependencies defined in more than one place. This script provides definitions for version numbers that are derived from a single source - the project.clj file.

The script assumes that the elements of :dependencies vectors are separated by spaces only, and that there is only one set of :dependencies in the file. It depends on _bash_, _sed_ and _tr_. _sed_ is the wildcard. The script is tested on OS X with the system sed and with MacPorts gsed, and on Ubuntu 16.04, but would benefit from testing with whatever other versions may be encountered in the wild.

Run the script this way:
`$ cat project.clj | proj-deps`
The bash assignments are written to stdout.

To set up the env-vars, do:
`$ eval $(cat project.clj | proj-deps)`

If it's found to be reliable, it can be used to set up vars in individual script directory files.