### PR TITLE
Replaced all shebang by more portable ones

### DIFF
--- a/script/aot_core
+++ b/script/aot_core
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/script/self-compile
+++ b/script/self-compile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -rf classes
 mkdir classes


### PR DESCRIPTION
bash isn't located at /bin/bash on every system (e.g. NixOS).
So I replaced all shebang in the building scripts: #!/bin/bash -> #!/usr/bin/env bash.