### PR TITLE
Show all errors with cljs.spec/and instead of first fail only

### DIFF
--- a/src/main/cljs/cljs/spec.cljc
+++ b/src/main/cljs/cljs/spec.cljc
@@ -201,6 +201,17 @@
   [& pred-forms]
   `(and-spec-impl '~(mapv #(res &env %) pred-forms) ~(vec pred-forms) nil))
 
+(defmacro and-all
+  "Takes predicate/spec-forms, e.g.
+
+  (s/and even? #(< % 42))
+
+  Returns a spec that returns the conformed value. Successive
+  conformed values propagate through rest of predicates — invalid values are
+  reported)."
+  [& pred-forms]
+  `(and-all-spec-impl '~(mapv #(res &env %) pred-forms) ~(vec pred-forms) nil))
+
 (defn- res-kind
   [env opts]
   (let [{kind :kind :as mopts} opts]


### PR DESCRIPTION
`clojure.spec/and` only returns first problem for the sake of optimality. However in some case (`i.e.` form validation) it's useful to get the full list of problems.

Examples:

 - Returns only one problem for two failed specs
``` clojure
(let [a (fn [_] false)
      b (fn [_] false)]
  (s/explain-data (s/and a b) :stuff))
;; => returns only problem from a
```
- Returns different problem although data is the same
``` clojure
(let [a (fn [_] false)
      b (fn [_] false)]
  (s/explain-data (s/and b a) :stuff))
;; => returns only problem from b
```
- Returns all problems
``` clojure
(let [a (fn [_] false)
      b (fn [_] false)]
    (s/explain-data (s/and-all a b) :stuff))
;; => returns problems from a and b
```

I'm completely open to any suggestions to achieve same behaviour without new definitions or any advice to rewrite this PR. Of course maintainers can edit it 😄 