### PR TITLE
Fix Build/Uberjar Errors

### DIFF
--- a/script/build
+++ b/script/build
@@ -11,7 +11,7 @@ fi
 
 cd `dirname $0`/..
 rm -rf target
-rm resources/brepl_client.js
+rm -f resources/brepl_client.js
 
 POM_TEMPLATE="pom.template.xml"
 POM_FILE="pom.xml"

--- a/script/uberjar
+++ b/script/uberjar
@@ -9,7 +9,7 @@ if [[ -z "$CLJS_SCRIPT_QUIET" ]]; then
   set -x
 fi
 
-rm resources/brepl_client.js
+rm -f resources/brepl_client.js
 
 # The command `git describe --match v0.0` will return a string like
 #


### PR DESCRIPTION
@swannodette `resources/brepl_client.js` needs to be `rm -f`'d, because it doesn't exist on a fresh clone.