### PR TITLE
use __dirname instead of "."

### DIFF
--- a/src/main/clojure/cljs/closure.clj
+++ b/src/main/clojure/cljs/closure.clj
@@ -1584,8 +1584,8 @@
                       "    require(\"source-map-support\").install();\n"
                       "} catch(err) {\n"
                       "}\n"
-                      "require(path.join(path.resolve(\".\"),\"" asset-path "\",\"goog\",\"bootstrap\",\"nodejs.js\"));\n"
-                      "require(path.join(path.resolve(\".\"),\"" asset-path "\",\"cljs_deps.js\"));\n"
+                      "require(path.join(path.resolve(\"__dirname\"),\"" asset-path "\",\"goog\",\"bootstrap\",\"nodejs.js\"));\n"
+                      "require(path.join(path.resolve(\"__dirname\"),\"" asset-path "\",\"cljs_deps.js\"));\n"
                       "goog.global.CLOSURE_UNCOMPILED_DEFINES = " closure-defines ";\n"
                    (apply str (preloads (:preloads opts)))))
             (apply str


### PR DESCRIPTION
There's an issue when building clojurescript+electron apps using `electron-packager` or `electron-builder`: `path.resolve(".")` evaluates to "/" and dependencies are failed to load. 

Issue [described here](https://github.com/martinklepsch/electron-and-clojurescript/issues/8) in detail and seems to be common.

This dead simple solution worked for me, but i'm not familiar enough with codebase to be sure it woudn't break anything. (Notice: i replaced "." in generated code)

Any feedback?