### PR TITLE
CLJS-2893 seq should use .-length rather than alength

### DIFF
--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -1214,7 +1214,7 @@
         (IndexedSeq. coll 0 nil))
 
       (string? coll)
-      (when-not (zero? (alength coll))
+      (when-not (zero? (.-length coll))
         (IndexedSeq. coll 0 nil))
 
       (native-satisfies? ISeqable coll)


### PR DESCRIPTION
This was suggested by @mfikes (see https://twitter.com/mfikes/status/1037182264294207489) as a newb-friendly first PR.  I believe I saw in another tweet earlier this week that this speeds things up a bit.

See also https://dev.clojure.org/jira/browse/CLJS-2893