### PR TITLE
Make utility fns in cljs.spec.test.alpha private

### DIFF
--- a/src/main/cljs/cljs/spec/test/alpha.cljs
+++ b/src/main/cljs/cljs/spec/test/alpha.cljs
@@ -19,7 +19,7 @@
     [clojure.test.check :as stc]
     [clojure.test.check.properties]))
 
-(defn distinct-by
+(defn ^{:private true} distinct-by
   ([f coll]
    (let [step (fn step [xs seen]
                 (lazy-seq
@@ -42,13 +42,13 @@
   "if false, instrumented fns call straight through"
   true)
 
-(defn get-host-port []
+(defn ^{:private true} get-host-port []
   (if (not= "browser" *target*)
     {}
     {:host (.. js/window -location -host)
      :port (.. js/window -location -port)}))
 
-(defn get-ua-product []
+(defn ^{:private true} get-ua-product []
   (if (not= "browser" *target*)
     (keyword *target*)
     (cond
@@ -57,7 +57,7 @@
       product/FIREFOX :firefox
       product/IE :ie)))
 
-(defn get-env []
+(defn ^{:private true} get-env []
   {:ua-product (get-ua-product)})
 
 (defn- fn-spec?


### PR DESCRIPTION
I privatized the utility functions as mentioned by Mike Fikes that weren't supposed to be available for public use.