### PR TITLE
[CLJS-2735] Refines doc string for defmulti.

### DIFF
--- a/src/main/clojure/cljs/core.cljc
+++ b/src/main/clojure/cljs/core.cljc
@@ -2648,12 +2648,29 @@
 
 (core/defmacro defmulti
   "Creates a new multimethod with the associated dispatch function.
-  The docstring and attribute-map are optional.
+  The docstring and attr-map are optional.
 
   Options are key-value pairs and may be one of:
-    :default    the default dispatch value, defaults to :default
-    :hierarchy  the isa? hierarchy to use for dispatching
-                defaults to the global hierarchy"
+
+  :default
+
+  The default dispatch value, defaults to :default
+
+  :hierarchy the isa? hierarchy to use for dispatching
+                defaults to the global hierarchy.
+
+  The value used for hierarchical dispatch (e.g. ::square is-a ::shape)
+
+  Hierarchies are type-like relationships that do not depend upon type
+  inheritance. By default Clojure's multimethods dispatch off of a
+  global hierarchy map.  However, a hierarchy relationship can be
+  created with the derive function used to augment the root ancestor
+  created with make-hierarchy.
+
+  Multimethods expect the value of the hierarchy option to be supplied as
+  a reference type e.g. a var (i.e. via the Var-quote dispatch macro #'
+  or the var special form)."
+
   {:arglists '([name docstring? attr-map? dispatch-fn & options])}
   [mm-name & options]
   (core/let [docstring   (if (core/string? (first options))


### PR DESCRIPTION
This commit updates the doc string for defmulti as described in the JIRA Ticket, [CLJS-2735](https://dev.clojure.org/jira/browse/CLJS-2735)