### PR TITLE
Fix bug where loader/load callback is not called on first load

### DIFF
--- a/src/main/cljs/cljs/loader.cljs
+++ b/src/main/cljs/cljs/loader.cljs
@@ -70,6 +70,7 @@
    (assert (contains? module-infos module-name)
      (str "Module " module-name " does not exist"))
    (let [mname (-> module-name name munge)]
+     (.beforeLoadModuleCode loader/*module-manager* mname)
      (if-not (nil? cb)
        (.execOnLoad *module-manager* mname cb)
        (.load *module-manager* mname)))))
@@ -83,7 +84,9 @@
     (str "Module " module-name " does not exist"))
   (let [xs (deps-for module-name module-infos)]
     (doseq [x xs]
+      (.setLoaded loader/*module-manager* (munge-kw x))
       (.setLoaded (.getModuleInfo *module-manager* (munge-kw x))))
+    (.setLoaded loader/*module-manager* (munge-kw module-name))
     (.setLoaded (.getModuleInfo *module-manager* (munge-kw module-name)))))
 
 (defn prefetch

--- a/src/main/cljs/cljs/loader.cljs
+++ b/src/main/cljs/cljs/loader.cljs
@@ -84,10 +84,14 @@
     (str "Module " module-name " does not exist"))
   (let [xs (deps-for module-name module-infos)]
     (doseq [x xs]
-      (.setLoaded *module-manager* (munge-kw x))
-      (.setLoaded (.getModuleInfo *module-manager* (munge-kw x))))
-    (.setLoaded *module-manager* (munge-kw module-name))
-    (.setLoaded (.getModuleInfo *module-manager* (munge-kw module-name)))))
+      (let [munged-x (munge-kw x)]
+        (when (.isModuleLoading *module-manager* munged-x)
+          (.setLoaded *module-manager* munged-x)
+          (.setLoaded (.getModuleInfo *module-manager* munged-x)))))
+    (let [munged-module-name (munge-kw module-name)]
+      (when (.isModuleLoading *module-manager* munged-module-name)
+        (.setLoaded *module-manager* munged-module-name)
+        (.setLoaded (.getModuleInfo *module-manager* munged-module-name))))))
 
 (defn prefetch
   "Prefetch a module. module-name should be a keyword matching a :modules

--- a/src/main/cljs/cljs/loader.cljs
+++ b/src/main/cljs/cljs/loader.cljs
@@ -86,12 +86,12 @@
     (doseq [x xs]
       (let [munged-x (munge-kw x)]
         (when (.isModuleLoading *module-manager* munged-x)
-          (.setLoaded *module-manager* munged-x)
-          (.setLoaded (.getModuleInfo *module-manager* munged-x)))))
+          (.setLoaded *module-manager* munged-x))
+        (.setLoaded (.getModuleInfo *module-manager* munged-x))))
     (let [munged-module-name (munge-kw module-name)]
       (when (.isModuleLoading *module-manager* munged-module-name)
-        (.setLoaded *module-manager* munged-module-name)
-        (.setLoaded (.getModuleInfo *module-manager* munged-module-name))))))
+        (.setLoaded *module-manager* munged-module-name))
+      (.setLoaded (.getModuleInfo *module-manager* munged-module-name)))))
 
 (defn prefetch
   "Prefetch a module. module-name should be a keyword matching a :modules

--- a/src/main/cljs/cljs/loader.cljs
+++ b/src/main/cljs/cljs/loader.cljs
@@ -70,7 +70,7 @@
    (assert (contains? module-infos module-name)
      (str "Module " module-name " does not exist"))
    (let [mname (-> module-name name munge)]
-     (.beforeLoadModuleCode loader/*module-manager* mname)
+     (.beforeLoadModuleCode *module-manager* mname)
      (if-not (nil? cb)
        (.execOnLoad *module-manager* mname cb)
        (.load *module-manager* mname)))))
@@ -84,9 +84,9 @@
     (str "Module " module-name " does not exist"))
   (let [xs (deps-for module-name module-infos)]
     (doseq [x xs]
-      (.setLoaded loader/*module-manager* (munge-kw x))
+      (.setLoaded *module-manager* (munge-kw x))
       (.setLoaded (.getModuleInfo *module-manager* (munge-kw x))))
-    (.setLoaded loader/*module-manager* (munge-kw module-name))
+    (.setLoaded *module-manager* (munge-kw module-name))
     (.setLoaded (.getModuleInfo *module-manager* (munge-kw module-name)))))
 
 (defn prefetch


### PR DESCRIPTION
Hi!

I noticed the loader/load callback was not getting called unless the module was already loaded. I managed to trace it down to `setLoaded(id)` not being called on `goog.module.ModuleManager`. Oddly, calling that also required first calling `beforeLoadModuleCode(id)` manually which feels weird but I couldn't find any other way to do it.

In other words this might not be the right way to fix this but I though I'd put it up for discussion.