### PR TITLE
CLJS-3317: PersistentVector invoke does not align with Clojure

### DIFF
--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -5693,9 +5693,9 @@ reduces them without incurring seq initialization"
 
   IFn
   (-invoke [coll k]
-    (-nth coll k))
-  (-invoke [coll k not-found]
-    (-nth coll k not-found))
+    (if (number? k)
+      (-nth coll k)
+      (throw (js/Error. "Key must be integer"))))
 
   IEditableCollection
   (-as-transient [coll]

--- a/src/test/cljs/cljs/collections_test.cljs
+++ b/src/test/cljs/cljs/collections_test.cljs
@@ -1080,6 +1080,10 @@
     (persistent! t)
     (is (= :fail (try (get t :a :not-found) (catch js/Error e :fail))))))
 
+(deftest test-cljs-3317
+  (testing "persistent vector invoke matches clojure"
+    (is (thrown-with-msg? js/Error #"Key must be integer" ([1 2] nil)))))
+
 (comment
 
   (run-tests)


### PR DESCRIPTION
Remove not-found case - does not exist in Clojure. Throw if k is not a number.