### PR TITLE
add update-vals and update-keys

### DIFF
--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -11720,6 +11720,35 @@ reduces them without incurring seq initialization"
           (tap x)
           (catch js/Error ex))))))
 
+(defn update-vals
+  "m f => {k (f v) ...}
+  Given a map m and a function f of 1-argument, returns a new map where the keys of m
+  are mapped to result of applying f to the corresponding values of m."
+  {:added "1.11"}
+  [m f]
+  (with-meta
+    (persistent!
+      (reduce-kv (fn [acc k v] (assoc! acc k (f v)))
+                 (if (instance? IEditableCollection m)
+                   (transient m)
+                   (transient {}))
+                 m))
+    (meta m)))
+
+(defn update-keys
+  "m f => {(f k) v ...}
+  Given a map m and a function f of 1-argument, returns a new map whose
+  keys are the result of applying f to the keys of m, mapped to the
+  corresponding values of m.
+  f must return a unique key for each key of m, else the behavior is undefined."
+  {:added "1.11"}
+  [m f]
+  (let [ret (persistent!
+              (reduce-kv (fn [acc k v] (assoc! acc (f k) v))
+                         (transient {})
+                         m))]
+    (with-meta ret (meta m))))
+
 ;; -----------------------------------------------------------------------------
 ;; Bootstrap helpers - incompatible with advanced compilation
 

--- a/src/test/cljs/cljs/core_test.cljs
+++ b/src/test/cljs/cljs/core_test.cljs
@@ -1874,3 +1874,21 @@
             (for [e s :when (and (sequential? e) (every? (fn [x] x) e))]
               e))
           [[]]))))
+
+(deftest test-update-vals
+  (let [inm  (with-meta {:a 1 :b 2} {:has :meta})]
+    (are [result expr] (= result expr)
+                       {:a 2 :b 3}   (update-vals inm inc)
+                       {:has :meta}  (meta (update-vals inm inc))
+                       {0 2 2 4}     (update-vals (hash-map 0 1 2 3) inc)
+                       {0 2 2 4}     (update-vals (array-map 0 1 2 3) inc)
+                       {0 2 2 4}     (update-vals (sorted-map 2 3 0 1) inc))))
+
+(deftest test-update-keys
+  (let [inm  (with-meta {:a 1 :b 2} {:has :meta})]
+    (are [result expr] (= result expr)
+                       {"a" 1 "b" 2} (update-keys inm name)
+                       {:has :meta}  (meta (update-keys inm name))
+                       {1 1 3 3}     (update-keys (hash-map 0 1 2 3) inc)
+                       {1 1 3 3}     (update-keys (array-map 0 1 2 3) inc)
+                       {1 1 3 3}     (update-keys (sorted-map 2 3 0 1) inc))))


### PR DESCRIPTION
To keep up to date with Clojure:
https://clojure.org/releases/devchangelog#v1.11.0-alpha2

CLJ-1959 Add implementation of update-keys
CLJ-2651 Add implementation of update-vals