### PR TITLE
set `error` on ex-info for better broswer support

### DIFF
--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -11477,6 +11477,7 @@ reduces them without incurring seq initialization"
   (let [e (js/Error. message)]
     (this-as this
       (set! (.-message this) message)
+      (set! (.-error this) message)
       (set! (.-data this) data)
       (set! (.-cause this) cause)
       (do


### PR DESCRIPTION
See discussion https://ask.clojure.org/index.php/11159/suggestion-to-improve-default-info-printing-clojurescript

To observe the behavior, try throwing these two expressions:

    (throw (ex-info "oh no" {}))

    (throw (set! (.-error (ex-info "oh no" {})) "oh no"))

And observe that the second form is more browser friendly.