### PR TITLE
CLJS-3294: data_readers.cljc doesn't provide a way to have target-specific behaviour

### DIFF
--- a/src/main/cljs/cljs/reader.clj
+++ b/src/main/cljs/cljs/reader.clj
@@ -13,6 +13,6 @@
   (let [data-readers
         (->> (get @env/*compiler* :cljs.analyzer/data-readers)
           (map (fn [[k v]]
-                 `['~k (fn [x#] (~(vary-meta v assoc :cljs.analyzer/no-resolve true) x#))]))
+                 `['~k (fn [x#] (~(vary-meta (-> v meta :sym) assoc :cljs.analyzer/no-resolve true) x#))]))
           (into {}))]
     `(do (merge ~default-readers ~data-readers))))

--- a/src/main/clojure/cljs/core/server.clj
+++ b/src/main/clojure/cljs/core/server.clj
@@ -91,7 +91,8 @@
                       (when (try
                               (let [[form s] (binding [*ns* (create-ns ana/*cljs-ns*)
                                                        reader/resolve-symbol ana/resolve-symbol
-                                                       reader/*data-readers* tags/*cljs-data-readers*
+                                                       reader/*data-readers* (merge tags/*cljs-data-readers*
+                                                                               (ana/load-data-readers))
                                                        reader/*alias-map*
                                                        (apply merge
                                                          ((juxt :requires :require-macros)

--- a/src/main/clojure/cljs/repl.cljc
+++ b/src/main/clojure/cljs/repl.cljc
@@ -1143,7 +1143,8 @@
                (fn []
                  (let [input (binding [*ns* (create-ns ana/*cljs-ns*)
                                        reader/resolve-symbol ana/resolve-symbol
-                                       reader/*data-readers* tags/*cljs-data-readers*
+                                       reader/*data-readers* (merge tags/*cljs-data-readers*
+                                                               (ana/load-data-readers))
                                        reader/*alias-map*
                                        (apply merge
                                          ((juxt :requires :require-macros :as-aliases)
@@ -1510,7 +1511,8 @@ itself (not its value) is returned. The reader macro #'x expands to (var x)."}})
             (let [rdr (readers/source-logging-push-back-reader pbr)]
               (dotimes [_ (dec (:line v))] (readers/read-line rdr))
               (binding [reader/*alias-map*    identity
-                        reader/*data-readers* tags/*cljs-data-readers*]
+                        reader/*data-readers* (merge tags/*cljs-data-readers*
+                                                (ana/load-data-readers))]
                 (-> (reader/read {:read-cond :allow :features #{:cljs}} rdr)
                   meta :source)))))))))
 

--- a/src/test/cljs/data_readers.cljc
+++ b/src/test/cljs/data_readers.cljc
@@ -9,4 +9,5 @@
 {cljs/tag clojure.core/identity
  cljs/inc clojure.core/inc
  cljs/union clojure.set/union
- test/custom-identity data-readers-test.core/custom-identity}
+ test/custom-identity data-readers-test.core/custom-identity
+ test/custom-form #?(:cljs data-readers-test.core/custom-form-cljs :clj clojure.core/identity)}

--- a/src/test/cljs/data_readers_test/core.cljc
+++ b/src/test/cljs/data_readers_test/core.cljc
@@ -11,3 +11,15 @@
 (def custom-identity identity)
 
 (assert (= 1 #test/custom-identity 1))
+
+(defn custom-form-cljs 
+  "a clojure and clojurescript function - in both cases targeting only cljs. 
+  
+  returns a clojurescript form (from :clj branch, when compiling) 
+  and executes js from :cljs branch when using cljs.reader/read"
+  [x]
+  #?(:clj `(js/Array.of ~x)
+     :cljs (js/Array.of x)))
+
+#?(:cljs
+   (def result #test/custom-form"foo"))

--- a/src/test/clojure/cljs/build_api_tests.clj
+++ b/src/test/clojure/cljs/build_api_tests.clj
@@ -456,7 +456,11 @@
         cenv (env/default-compiler-env)]
     (test/delete-out-files out)
     (build/build (build/inputs (io/file inputs "data_readers_test")) opts cenv)
-    (is (contains? (-> @cenv ::ana/data-readers) 'test/custom-identity))))
+    (is (contains? (-> @cenv ::ana/data-readers) 'test/custom-identity))
+    (is (true? (boolean (re-find #"Array\.of\(\"foo\"\)"
+                          (slurp (io/file 
+                                   out ;"data-readers-test-out"
+                                   "data_readers_test" "core.js"))))))))
 
 (deftest test-data-readers-records
   (let [out (.getPath (io/file (test/tmp-dir) "data-readers-test-records-out"))


### PR DESCRIPTION
 - The function that reads the data_readers.cljc files from the classpath has been moved to the analyzer ns, so that custom literals are available to the ana/forms-seq fns also.

- in cljs.reader/add-data-readers macro, the set of custom data-readers returned is the fully qualified var names of those readers - as those will be interpreted as cljs functions.