### PR TITLE
CLJS-3347: Create clojure.math namespace

### DIFF
--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -2712,6 +2712,11 @@ reduces them without incurring seq initialization"
   "Returns a number one less than num."
   [x] (- x 1))
 
+(defn ^number abs
+  {:doc "Returns the absolute value of a."
+   :added "1.11.10"}
+  [a] (Math/abs a))
+
 (defn ^number max
   "Returns the greatest of the nums."
   ([x] x)

--- a/src/main/cljs/cljs/math.cljs
+++ b/src/main/cljs/cljs/math.cljs
@@ -1,0 +1,869 @@
+(ns ^{:doc "ClojureScript wrapper functions for math operations"
+      :author "Paula Gearon" }
+    cljs.math)
+
+(def
+  ^{:doc "Constant for Euler's number e, the base for natural logarithms.
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E"
+    :added "1.11.10"
+    :tag number
+    :const true} E Math/E)
+
+(def
+  ^{:doc "Constant for pi, the ratio of the circumference of a circle to its diameter.
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/PI"
+    :added "1.11.10"
+    :tag number
+    :const true} PI Math/PI)
+
+(def
+  ^{:doc "Constant used to convert an angular value in degrees to the equivalent in radians"
+    :private true
+    :added "1.11.10"
+    :const true} DEGREES-TO-RADIANS 0.017453292519943295)
+
+(def
+  ^{:doc "Constant used to convert an angular value in radians to the equivalent in degrees"
+    :private true
+    :added "1.11.10"
+    :const true} RADIANS-TO-DEGREES 57.29577951308232)
+
+(def ^{:private true :const true} TWO-TO-THE-52 0x10000000000000)
+
+(def ^{:private true :const true} SIGNIFICAND-WIDTH32 21)
+
+(def ^{:private true :const true} EXP-BIAS 1023)
+
+(def ^{:private true :const true} EXP-BITMASK32 0x7FF00000)
+
+(def ^{:private true :const true} EXP-MAX EXP-BIAS)
+
+(def ^{:private true :const true} EXP-MIN -1022)
+
+;; js/Number.MIN_VALUE has a bit representation of 0x0000000000000001
+
+;; js/Number.MAX_VALUE has a bit representation of 0x7FEFFFFFFFFFFFFF
+
+(defn- get-little-endian
+  "Tests the platform for endianness. Returns true when little-endian, false otherwise."
+  []
+  (let [a (js/ArrayBuffer. 4)
+        i (js/Uint32Array. a)
+        b (js/Uint8Array. a)]
+    (aset i 0 0x33221100)
+    (zero? (aget b 0))))
+
+(defonce ^:private little-endian? (get-little-endian))
+
+;; the HI and LO labels are terse to reflect the C macros they represent
+(def ^{:private true :doc "offset of hi integers in 64-bit values"} HI (if little-endian? 1 0))
+
+(def ^{:private true :doc "offset of hi integers in 64-bit values"} LO (- 1 HI))
+
+(def ^{:private true :const true} INT32-MASK 0xFFFFFFFF)
+
+(def ^{:private true :const true} INT32-NON-SIGN-BIT 0x80000000)
+
+(def ^{:private true :const true} INT32-NON-SIGN-BITS 0x7FFFFFFF)
+
+(defn u<
+  {:doc "unsigned less-than comparator for 32-bit values"
+   :private true}
+  [a b]
+  ;; compare the top nybble
+  (let [ab (unsigned-bit-shift-right a 28)
+        bb (unsigned-bit-shift-right b 28)]
+    (or (< ab bb)  ;; if the top nybble of a is less then the whole value is less
+        (and (== ab bb)  ;; if the top nybble is equal then compare the remaining bits of both
+             (< (bit-and a 0x0fffffff) (bit-and b 0x0fffffff))))))
+
+(defn ^number sin
+  {:doc "Returns the sine of an angle.
+  If a is ##NaN, ##-Inf, ##Inf => ##NaN
+  If a is zero => zero with the same sign as a
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sin"
+   :added "1.11.10"}
+  [a] (Math/sin a))
+
+(defn ^number cos
+  {:doc "Returns the cosine of an angle.
+  If a is ##NaN, ##-Inf, ##Inf => ##NaN
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cos"
+   :added "1.11.10"}
+  [a] (Math/cos a))
+
+(defn ^number tan
+  {:doc "Returns the tangent of an angle.
+  If a is ##NaN, ##-Inf, ##Inf => ##NaN
+  If a is zero => zero with the same sign as a
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/tan"
+   :added "1.11.10"}
+  [a] (Math/tan a))
+
+(defn ^number asin
+  {:doc "Returns the arc sine of an angle, in the range -pi/2 to pi/2.
+  If a is ##NaN or |a|>1 => ##NaN
+  If a is zero => zero with the same sign as a
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asin"
+   :added "1.11.10"}
+  [a] (Math/asin a))
+
+(defn ^number acos
+  {:doc "Returns the arc cosine of a, in the range 0.0 to pi.
+  If a is ##NaN or |a|>1 => ##NaN
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acos"
+   :added "1.11.10"}
+  [a] (Math/acos a))
+
+(defn ^number atan
+  {:doc "Returns the arc tangent of a, in the range of -pi/2 to pi/2.
+  If a is ##NaN => ##NaN
+  If a is zero => zero with the same sign as a
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan"
+   :added "1.11.10"}
+  [a] (Math/atan a))
+
+(defn ^number to-radians
+  {:doc "Converts an angle in degrees to an approximate equivalent angle in radians.
+  See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#toRadians-double-"
+   :added "1.11.10"}
+  [deg]
+  (* deg DEGREES-TO-RADIANS))
+
+(defn ^number to-degrees
+  {:doc "Converts an angle in radians to an approximate equivalent angle in degrees.
+  See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#toDegrees-double-"
+   :added "1.11.10"}
+  [r]
+  (* r RADIANS-TO-DEGREES))
+
+(defn ^number exp
+  {:doc "Returns Euler's number e raised to the power of a.
+  If a is ##NaN => ##NaN
+  If a is ##Inf => ##Inf
+  If a is ##-Inf => +0.0
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/exp"
+   :added "1.11.10"}
+  [a] (Math/exp a))
+
+(defn ^number log
+  {:doc "Returns the natural logarithm (base e) of a.
+  If a is ##NaN or negative => ##NaN
+  If a is ##Inf => ##Inf
+  If a is zero => ##-Inf
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log"
+   :added "1.11.10"}
+  [a] (Math/log a))
+
+(defn ^number log10
+  {:doc "Returns the logarithm (base 10) of a.
+  If a is ##NaN or negative => ##NaN
+  If a is ##Inf => ##Inf
+  If a is zero => ##-Inf
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log10"
+   :added "1.11.10"}
+  [a] (Math/log10 a))
+
+(defn ^number sqrt
+  {:doc "Returns the positive square root of a.
+  If a is ##NaN or negative => ##NaN
+  If a is ##Inf => ##Inf
+  If a is zero => a
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt"
+   :added "1.11.10"}
+  [a] (Math/sqrt a))
+
+(defn ^number cbrt
+  {:doc "Returns the cube root of a.
+  If a is ##NaN => ##NaN
+  If a is ##Inf or ##-Inf => a
+  If a is zero => zero with sign matching a
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt"
+   :added "1.11.10"}
+  [a] (Math/cbrt a))
+
+(defn ^number fabs
+  {:doc "Internal function to convert doubles to absolute values.
+  This duplicates the C implementations in Java, in case there is are corner-case differences."
+   :private true
+   :added "1.11.10"}
+  [x]
+  ;; create a buffer large enough for a double
+  (let [a (js/ArrayBuffer. 8)
+        ;; represent the buffer as a double array
+        d (js/Float64Array. a)
+        ;; represent the buffer as 32 bit ints
+        i (js/Uint32Array. a)
+        hi (if little-endian? 1 0)]
+    ;; insert the double value into the buffer
+    (aset d 0 x)
+    ;; update the sign bit
+    (aset i hi (bit-and (aget i hi) INT32-NON-SIGN-BITS))
+    ;; return the new double
+    (aget d 0)))
+
+(def ^{:private true} Zero
+  ;; a buffer that can hold a pair of 64 bit doubles
+  (let [a (js/ArrayBuffer. 16)
+        ;; represent the buffer as a 2 double array
+        d (js/Float64Array. a)
+        ;; represent the buffer as an array of bytes
+        b (js/Uint8Array. a)]
+    ;; initialize both doubles to 0.0
+    (aset d 0 0.0)
+    (aset d 1 0.0)
+    ;; update the sign bit on the second double
+    (aset b (if little-endian? 15 8) -0x80)
+    ;; save the array of 2 doubles [0.0, -0.0]
+    d))
+
+(def ^{:private true :const true} xpos 0)
+(def ^{:private true :const true} ypos 1)
+(def ^{:private true} HI-x (+ (* 2 xpos) HI))
+(def ^{:private true} LO-x (+ (* 2 xpos) LO))
+(def ^{:private true} HI-y (+ (* 2 ypos) HI))
+(def ^{:private true} LO-y (+ (* 2 ypos) LO))
+
+(defn ^number ilogb
+  {:doc "internal function for ilogb(x)"
+   :private true}
+  [hx lx]
+  (if (< hx 0x00100000) ;; subnormal
+    (let [hx-zero? (zero? hx)
+          start-ix (if hx-zero? -1043 -1022)
+          start-i (if hx-zero? lx (bit-shift-left hx 11))]
+      (loop [ix start-ix i start-i]
+        (if-not (> i 0)
+          ix
+          (recur (dec ix) (bit-shift-left i 1)))))
+    (- (bit-shift-right hx 20) 1023)))
+
+(defn ^number setup-hl
+  {:doc "internal function to setup and align integer words"
+   :private true}
+  [i h l]
+  (if (>= i -1022)
+    [(bit-or 0x00100000 (bit-and 0x000fffff h)) l]
+    (let [n (- -1022 i)]
+      (if (<= n 31)
+        [(bit-or (bit-shift-left h n) (unsigned-bit-shift-right l (- 32 n))) (bit-shift-left l n)]
+        [(bit-shift-left l (- n 32)) 0]))))
+
+(defn ^number IEEE-fmod
+  {:doc "Return x mod y in exact arithmetic. Method: shift and subtract.
+  Reimplements __ieee754_fmod from the JDK.
+  Ported from: https://github.com/openjdk/jdk/blob/master/src/java.base/share/native/libfdlibm/e_fmod.c
+  bit-shift-left and bit-shift-right convert numbers to signed 32-bit
+  Fortunately the values that are shifted are expected to be 32 bit signed."
+  :private true}
+  [x y]
+  ;; return exception values
+  (if (or (zero? y) ^boolean (js/isNaN y) (not ^boolean (js/isFinite x)))
+    ##NaN
+
+    ;; create a buffer large enough for 2 doubles
+    (let [a (js/ArrayBuffer. 16)
+          ;; represent the buffer as a double array
+          d (js/Float64Array. a)
+          ;; represent the buffer as 32 bit ints
+          i (js/Uint32Array. a)
+          ;; set the doubles to x and y
+          _ (aset d xpos x)
+          _ (aset d ypos y)
+          hx (aget i HI-x)
+          lx (aget i LO-x)
+          hy (aget i HI-y)
+          ly (aget i LO-y)
+          sx (bit-and hx INT32-NON-SIGN-BIT) ;; capture the sign of x
+          hx (bit-and hx INT32-NON-SIGN-BITS) ;; set x to |x|
+          hy (bit-and hy INT32-NON-SIGN-BITS) ;; set y to |y|
+          hx<=hy (<= hx hy)]
+      (cond
+        ;; additional exception values
+        (and hx<=hy (or (< hx hy) (< lx ly))) x ;; |x|<|y| return x
+        (and hx<=hy (== lx ly)) (aget Zero (unsigned-bit-shift-right sx 31)) ;; |x|=|y| return x*0
+
+        :default
+        ;; determine ix = ilogb(x), iy = ilogb(y)
+        (try
+          (let [ix (ilogb hx lx)
+                iy (ilogb hy ly)
+                ;; set up {hx,lx}, {hy,ly} and align y to x
+                [hx lx] (setup-hl ix hx lx)
+                [hy ly] (setup-hl iy hy ly)
+                ;; fix point fmod
+                [hx lx] (loop [n (- ix iy) hx hx lx lx]
+                          (if (zero? n)
+                            [hx lx]
+                            (let [hz (if (u< lx ly) (- hx hy 1) (- hx hy))
+                                  lz (- lx ly)
+                                  [hx lx] (if (< hz 0)
+                                            [(+ hx hx (unsigned-bit-shift-right lx 31)) (+ lx lx)]
+                                            (if (zero? (bit-or hz lz))
+                                              (throw (ex-info "Signed zero" {:zero true}))
+                                              [(+ hz hz (unsigned-bit-shift-right lz 31)) (+ lz lz)]))]
+                              (recur (dec n) (bit-and INT32-MASK hx) (bit-and INT32-MASK lx)))))
+                hz (if (u< lx ly) (- hx hy 1) (- hx hy))
+                lz (- lx ly)
+                [hx lx] (if (>= hz 0) [hz lz] [hx lx])
+
+                _ (when (zero? (bit-or hx lx))
+                    (throw (ex-info "Signed zero" {:zero true})))
+                ;; convert back to floating value and restore the sign
+                [hx lx iy] (loop [hx hx lx lx iy iy]
+                             (if-not (< hx 0x00100000)
+                               [hx lx iy]
+                               (recur (+ hx hx (unsigned-bit-shift-right lx 31)) (+ lx lx) (dec iy))))]
+            ;; use these high and low ints to update the double and return it
+            (if (>= iy -1022)
+              (let [hx (bit-or (- hx 0x00100000) (bit-shift-left (+ iy 1023) 20))]
+                (aset i HI-x (bit-or hx sx))
+                (aset i LO-x lx)
+                (aget d xpos))
+              (let [n (- -1022 iy)
+                    [hx lx] (cond
+                              (<= n 20) [(bit-shift-right hx n)
+                                         (bit-or (unsigned-bit-shift-right lx n) (bit-shift-left hx (- 32 n)))]
+                              (<= n 31) [sx
+                                         (bit-or (bit-shift-left hx (- 32 n)) (unsigned-bit-shift-right lx n))]
+                              :default [sx (bit-shift-right hx (- n 32))])]
+                (aset i HI-x (bit-or hx sx))
+                (aset i LO-x lx)
+                (* (aget d xpos) 1.0))))
+          (catch :default _ (aget Zero (unsigned-bit-shift-right sx 31))))))))
+
+(defn ^number IEEE-remainder
+  {:doc "Returns the remainder per IEEE 754 such that
+    remainder = dividend - divisor * n
+   where n is the integer closest to the exact value of dividend / divisor.
+   If two integers are equally close, then n is the even one.
+   If the remainder is zero, sign will match dividend.
+   If dividend or divisor is ##NaN, or dividend is ##Inf or ##-Inf, or divisor is zero => ##NaN
+   If dividend is finite and divisor is infinite => dividend
+
+   Method: based on fmod return x-[x/p]chopped*p exactlp.
+   Ported from: https://github.com/openjdk/jdk/blob/master/src/java.base/share/native/libfdlibm/e_remainder.c
+   See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#IEEEremainder-double-double-"
+    :added "1.11.10"}
+  [dividend divisor]
+  ;; check for exception values
+  (cond
+    (zero? divisor) ##NaN
+    ^boolean (js/isNaN divisor) ##NaN
+    ;; check if dividend is ##Inf ##-Inf or ##NaN
+    ^boolean (js/isNaN dividend) ##NaN
+    (not ^boolean (js/isFinite dividend)) ##NaN
+    ;; dividend is finish, check if divisor is infinite
+    (not ^boolean (js/isFinite divisor)) dividend
+
+    :default
+    ;; create a buffer large enough for 2 doubles
+    (let [a (js/ArrayBuffer. 16)
+          ;; represent the buffer as a double array
+          d (js/Float64Array. a)
+          ;; represent the buffer as 32 bit ints
+          i (js/Uint32Array. a)]
+      (aset d 0 dividend)
+      (aset d 1 divisor)
+      ;; x gets the dividend high and low ints
+      (let [hx (aget i HI)
+            lx (aget i LO)
+            ;; p gets the divisor high and low ints
+            hp (aget i (+ HI 2))
+            lp (aget i (+ LO 2))
+            ;; sx is the sign bit
+            sx (bit-and hx INT32-NON-SIGN-BIT)
+            ;; strip the sign bit from hp and hx
+            hp (bit-and hp INT32-NON-SIGN-BITS)
+            hx (bit-and hx INT32-NON-SIGN-BITS)
+
+            ;;make x < 2p
+            dividend (if (<= hp 0x7FDFFFFF) (IEEE-fmod dividend (+ divisor divisor)) dividend)]
+        (if (zero? (bit-or (- hx hp) (- lx lp)))
+          (* 0.0 dividend)
+          ;; convert dividend and divisor to absolute values. 
+          (let [dividend (Math/abs dividend)
+                divisor (Math/abs divisor)
+                ;; reduce dividend within range of the divisor
+                dividend (if (< hp 0x00200000)
+                           ;; smaller divisor compare 2*dividend to the divisor
+                           (if (> (+ dividend dividend) divisor)
+                             (let [dividend (- dividend divisor)] ;; reduce the dividend
+                               (if (>= (+ dividend dividend) divisor) ;; 2*dividend still larger
+                                 (- dividend divisor) ;; reduce again
+                                 dividend))
+                             dividend)
+                           ;; compare dividend to half the divisor
+                           (let [divisor-half (* 0.5 divisor)]
+                             (if (> dividend divisor-half)
+                               (let [dividend (- dividend divisor)] ;; reduce the dividend
+                                 (if (>= dividend divisor-half) ;; still larger than half divisor
+                                   (- dividend divisor) ;; reduce again
+                                   dividend))
+                               dividend)))]
+            ;; update the buffer with the new dividend value
+            (aset d 0 dividend)
+            ;; calculate a new hi int for the dividend using the saved sign bit
+            (let [hx (bit-xor (aget i HI) sx)]
+              ;; set the dividend with this new sign bit
+              (aset i HI hx)
+              ;; retrieve the updated dividend
+              (aget d 0))))))))
+
+(defn ^number ceil
+  {:doc "Returns the smallest double greater than or equal to a, and equal to a
+  mathematical integer.
+  If a is ##NaN or ##Inf or ##-Inf or already equal to an integer => a
+  Note that if a is `nil` then an exception will be thrown. This matches Clojure, rather than js/Math.ceil
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil"
+   :added "1.11.10"}
+  [a]
+  (if (some? a)
+    (Math/ceil a)
+    (throw (ex-info "Unexpected Null passed to ceil" {:fn "ceil"}))))
+
+(defn ^number floor
+  {:doc "Returns the largest double less than or equal to a, and equal to a
+  mathematical integer.
+  If a is ##NaN or ##Inf or ##-Inf or already equal to an integer => a
+  If a is less than zero but greater than -1.0 => -0.0
+  Note that if a is `nil` then an exception will be thrown. This matches Clojure, rather than js/Math.floor
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor"
+   :added "1.11.10"}
+  [a]
+  (if (some? a)
+    (Math/floor a)
+    (throw (ex-info "Unexpected Null passed to floor" {:fn "floor"}))))
+
+(defn ^number copy-sign
+  {:doc "Returns a double with the magnitude of the first argument and the sign of
+  the second.
+  See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#copySign-double-double-"
+   :added "1.11.10"}
+  [magnitude sign]
+  ;; create a buffer large enough for 2 doubles
+  (let [a (js/ArrayBuffer. 16)
+        ;; represent the buffer as a double array
+        d (js/Float64Array. a)
+        ;; represent the buffer as bytes
+        b (js/Uint8Array. a)
+        ;; find the offset of the byte that holds the sign bit
+        sbyte (if little-endian? 7 0)]
+    ;; the first double holds the magnitude, the second holds the sign value
+    (aset d 0 magnitude)
+    (aset d 1 sign)
+    ;; read the sign bit from the sign value
+    (let [sign-sbyte (bit-and 0x80 (aget b (+ 8 sbyte)))
+          ;; read all the bits that aren't the sign bit in the same byte of the magnitude
+          mag-sbyte (bit-and 0x7F (aget b sbyte))]
+      ;; combine the sign bit from the sign value and the non-sign-bits from the magnitude value
+      ;; write it back into the byte in the magnitude
+      (aset b sbyte (bit-or sign-sbyte mag-sbyte))
+      ;; retrieve the full magnitude value with the updated byte
+      (aget d 0))))
+
+(defn ^number rint
+  {:doc "Returns the double closest to a and equal to a mathematical integer.
+  If two values are equally close, return the even one.
+  If a is ##NaN or ##Inf or ##-Inf or zero => a
+  See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#rint-double-"
+   :added "1.11.10"}
+  [a]
+  (let [sign (copy-sign 1.0, a)
+        a (Math/abs a)
+        a (if (< a TWO-TO-THE-52)
+            (- (+ TWO-TO-THE-52 a) TWO-TO-THE-52) a)]
+    (* sign a)))
+
+(defn ^number atan2
+  {:doc "Returns the angle theta from the conversion of rectangular coordinates (x, y) to polar coordinates (r, theta).
+  Computes the phase theta by computing an arc tangent of y/x in the range of -pi to pi.
+  For more details on special cases, see:
+  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan"
+   :added "1.11.10"}
+  [y x] (Math/atan2 y x))
+
+(defn ^number pow
+  {:doc "Returns the value of a raised to the power of b.
+  For more details on special cases, see:
+  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/pow"
+   :added "1.11.10"}
+  [a b] (Math/pow a b))
+
+(defn ^number round
+  {:doc "Returns the closest long to a. If equally close to two values, return the one
+  closer to ##Inf.
+  If a is ##NaN => 0
+  If a is ##-Inf => js/Number.MIN_SAFE_INTEGER
+  If a is ##Inf => js/Number.MAX_SAFE_INTEGER
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round"
+   :added "1.11.10"}
+  [a]
+  (cond
+    ^boolean (js/isNaN a) 0
+    ^boolean (js/isFinite a) (Math/round a)
+    (== ##Inf a) js/Number.MAX_SAFE_INTEGER
+    :default js/Number.MIN_SAFE_INTEGER))
+
+(defn ^number random
+  {:doc "Returns a positive double between 0.0 and 1.0, chosen pseudorandomly with
+  approximately random distribution. Not cryptographically secure. The seed is chosen internally
+  and cannot be selected.
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random"
+   :added "1.11.10"}
+  [] (Math/random))
+
+(defn ^number add-exact
+  {:doc "Returns the sum of x and y, throws an exception on overflow. "
+   :added "1.11.10"}
+  [x y]
+  (let [r (clojure.core/+ x y)]
+    (if (or (> r js/Number.MAX_SAFE_INTEGER) (< r js/Number.MIN_SAFE_INTEGER))
+      (throw (ex-info "Integer overflow" {:fn "add-exact"}))
+      r)))
+
+(defn ^number subtract-exact
+  {:doc "Returns the difference of x and y, throws ArithmeticException on overflow. "
+   :added "1.11.10"}
+  [x y]
+  (let [r (- x y)]
+    (if (or (> r js/Number.MAX_SAFE_INTEGER) (< r js/Number.MIN_SAFE_INTEGER))
+      (throw (ex-info "Integer overflow" {:fn "subtract-exact"}))
+      r)))
+
+(defn ^number multiply-exact
+  {:doc "Returns the product of x and y, throws ArithmeticException on overflow. "
+   :added "1.11.10"}
+  [x y]
+  (let [r (* x y)]
+    (if (or (> r js/Number.MAX_SAFE_INTEGER) (< r js/Number.MIN_SAFE_INTEGER))
+      (throw (ex-info "Integer overflow" {:fn "multiply-exact"}))
+      r)))
+
+(defn ^number increment-exact
+  {:doc "Returns a incremented by 1, throws ArithmeticException on overflow."
+   :added "1.11.10"}
+  [a]
+  (if (or (>= a js/Number.MAX_SAFE_INTEGER) (< a js/Number.MIN_SAFE_INTEGER))
+    (throw (ex-info "Integer overflow" {:fn "increment-exact"}))
+    (inc a)))
+
+(defn ^number decrement-exact
+  {:doc "Returns a decremented by 1, throws ArithmeticException on overflow. "
+   :added "1.11.10"}
+  [a]
+  (if (or (<= a js/Number.MIN_SAFE_INTEGER) (> a js/Number.MAX_SAFE_INTEGER))
+    (throw (ex-info "Integer overflow" {:fn "decrement-exact"}))
+    (dec a)))
+
+(defn ^number negate-exact
+  {:doc "Returns the negation of a, throws ArithmeticException on overflow. "
+   :added "1.11.10"}
+  [a]
+  (if (or (> a js/Number.MAX_SAFE_INTEGER) (< a js/Number.MIN_SAFE_INTEGER))
+    (throw (ex-info "Integer overflow" {:fn "negate-exact"}))
+    (- a)))
+
+(defn- xor
+  [^boolean a ^boolean b]
+  (or (and a (not b)) (and (not a) b)))
+
+(defn ^number floor-div
+  {:doc "Integer division that rounds to negative infinity (as opposed to zero).
+  See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#floorDiv-long-long-"
+   :added "1.11.10"}
+  [x y]
+  (if-not (and ^boolean (js/Number.isSafeInteger x) ^boolean (js/Number.isSafeInteger y))
+    (throw (ex-info "floor-div called with non-safe-integer arguments"
+                    {:x-int? (js/Number.isSafeInteger x) :y-int? (js/Number.isSafeInteger y)}))
+    (let [r (long (/ x y))]
+      (if (and (xor (< x 0) (< y 0)) (not (== (* r y) x)))
+        (dec r)
+        r))))
+
+(defn ^number floor-mod
+  {:doc "Integer modulus x - (floorDiv(x, y) * y). Sign matches y and is in the
+  range -|y| < r < |y|.
+  See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#floorMod-long-long-"
+   :added "1.11.10"}
+  [x y]
+  (if-not (and ^boolean (js/Number.isSafeInteger x) ^boolean (js/Number.isSafeInteger y))
+    (throw (ex-info "floor-mod called with non-safe-integer arguments"
+                    {:x-int? (js/Number.isSafeInteger x) :y-int? (js/Number.isSafeInteger y)}))
+    ;; this avoids using floor-div to keep within the safe integer range
+    (let [r (long (/ x y))]
+      (if (and (xor (< x 0) (< y 0)) (not (== (* r y) x)))
+        (- x (* y r) (- y))
+        (- x (* y r))))))
+
+(defn ^number get-exponent
+  {:doc "Returns the exponent of d.
+  If d is ##NaN, ##Inf, ##-Inf => Double/MAX_EXPONENT + 1
+  If d is zero or subnormal => Double/MIN_EXPONENT - 1
+  See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#getExponent-double-"
+   :added "1.11.10"}
+  [d]
+  (cond
+    (or ^boolean (js/isNaN d) (not ^boolean (js/isFinite d))) (inc EXP-MAX)
+    (zero? d) (dec EXP-MIN)
+    :default (let [a (js/ArrayBuffer. 8)
+                   f (js/Float64Array. a)
+                   i (js/Uint32Array. a)
+                   hi (if little-endian? 1 0)]
+               (aset f 0 d)
+               (- (bit-shift-right (bit-and (aget i hi) EXP-BITMASK32) (dec SIGNIFICAND-WIDTH32)) EXP-BIAS))))
+
+(defn ^number hi-lo->double
+  {:doc "Converts a pair of 32 bit integers into an IEEE-754 64 bit floating point number.
+  h is the high 32 bits, l is the low 32 bits."
+   :private true}
+  [h l]
+  (let [a (js/ArrayBuffer. 8)
+        f (js/Float64Array. a)
+        i (js/Uint32Array. a)]
+    (aset i LO l)
+    (aset i HI h)
+    (aget f 0)))
+
+(defn ^number power-of-two
+  {:doc "returns a floating point power of two in the normal range"
+   :private true}
+  [n]
+  (assert (and (>= n EXP-MIN) (<= n EXP-MAX)))
+  (hi-lo->double
+   (bit-and (bit-shift-left (+ n EXP-BIAS) (dec SIGNIFICAND-WIDTH32)) EXP-BITMASK32) 0))
+
+(defn ^number ulp
+  {:doc "Returns the size of an ulp (unit in last place) for d.
+  If d is ##NaN => ##NaN
+  If d is ##Inf or ##-Inf => ##Inf
+  If d is zero => Double/MIN_VALUE
+  If d is +/- Double/MAX_VALUE => 2^971
+  See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#ulp-double-"
+   :added "1.11.10"}
+  [d]
+  (cond
+    ^boolean (js/isNaN d) d
+    ^boolean (js/isFinite d)
+    (let [e (get-exponent d)]
+      (case e
+        1024 (Math/abs d)  ;; EXP-MAX + 1
+        -1023 js/Number.MIN_VALUE  ;; EXP-MIN - 1
+        (let [e (- e (+ 31 SIGNIFICAND-WIDTH32))]  ;; SIGNIFICAND_WIDTH64 -1
+          (if (>= e EXP-MIN)
+            (power-of-two e)
+            (let [shift (- e (- EXP-MIN 31 SIGNIFICAND-WIDTH32))]
+              (if (< shift 32)
+                (hi-lo->double 0 (bit-shift-left 1 shift))
+                (hi-lo->double (bit-shift-left 1 (- shift 32)) 0)))))))
+    :default ##Inf))
+
+(defn ^number signum
+  {:doc "Returns the signum function of d - zero for zero, 1.0 if >0, -1.0 if <0.
+  If d is ##NaN => ##NaN
+  If d is ##Inf or ##-Inf => sign of d
+  See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#signum-double-"
+   :added "1.11.10"}
+  [d]
+  (if (or (zero? d) ^boolean (js/isNaN d))
+    d
+    (copy-sign 1.0 d)))
+
+(defn ^number sinh
+  {:doc "Returns the hyperbolic sine of x, (e^x - e^-x)/2.
+  If x is ##NaN => ##NaN
+  If x is ##Inf or ##-Inf or zero => x
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sinh"
+   :added "1.11.10"}
+  [x] (Math/sinh x))
+
+(defn ^number cosh
+  {:doc "Returns the hyperbolic cosine of x, (e^x + e^-x)/2.
+  If x is ##NaN => ##NaN
+  If x is ##Inf or ##-Inf => ##Inf
+  If x is zero => 1.0
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh"
+   :added "1.11.10"}
+  [x] (Math/cosh x))
+
+(defn ^number tanh
+  {:doc "Returns the hyperbolic tangent of x, sinh(x)/cosh(x).
+  If x is ##NaN => ##NaN
+  If x is zero => zero, with same sign
+  If x is ##Inf => +1.0
+  If x is ##-Inf => -1.0
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/tanh"
+   :added "1.11.10"}
+  [x] (Math/tanh x))
+
+(defn ^number hypot
+  {:doc "Returns sqrt(x^2 + y^2) without intermediate underflow or overflow.
+  If x or y is ##Inf or ##-Inf => ##Inf
+  If x or y is ##NaN and neither is ##Inf or ##-Inf => ##NaN
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot"
+   :added "1.11.10"}
+  [x y] (Math/hypot x y))
+
+(defn ^number expm1
+  {:doc "Returns e^x - 1. Near 0, expm1(x)+1 is more accurate to e^x than exp(x).
+  If x is ##NaN => ##NaN
+  If x is ##Inf => #Inf
+  If x is ##-Inf => -1.0
+  If x is zero => x
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/expm1"
+   :added "1.11.10"}
+  [x] (Math/expm1 x))
+
+(defn ^number log1p
+  {:doc "Returns ln(1+x). For small values of x, log1p(x) is more accurate than
+  log(1.0+x).
+  If x is ##NaN or ##-Inf or < -1 => ##NaN
+  If x is -1 => ##-Inf
+  If x is ##Inf => ##Inf
+  See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p"
+   :added "1.11.10"}
+  [x] (Math/log1p x))
+
+(defn ^number add64
+  {:doc "Takes the high and low words for 2 different 64 bit integers, and adds them.
+  This handles overflow from the low-order words into the high order words."
+   :private true}
+  [hx lx hy ly]
+  (let [sx (unsigned-bit-shift-right (bit-and lx INT32-NON-SIGN-BIT) 31)
+        sy (unsigned-bit-shift-right (bit-and ly INT32-NON-SIGN-BIT) 31)
+        lr (+ (bit-and INT32-NON-SIGN-BITS lx) (bit-and INT32-NON-SIGN-BITS ly))
+        c31 (unsigned-bit-shift-right (bit-and lr INT32-NON-SIGN-BIT) 31)
+        b31 (+ sx sy c31)
+        lr (bit-or (bit-and lr INT32-NON-SIGN-BITS) (bit-shift-left b31 31))
+        c32 (bit-shift-right b31 1)
+        hr (bit-and INT32-MASK (+ hx hy c32))]
+    [hr lr]))
+
+(defn ^number next-after
+  {:doc "Returns the adjacent floating point number to start in the direction of
+  the second argument. If the arguments are equal, the second is returned.
+  If either arg is #NaN => #NaN
+  If both arguments are signed zeros => direction
+  If start is +-Double/MIN_VALUE and direction would cause a smaller magnitude
+    => zero with sign matching start
+  If start is ##Inf or ##-Inf and direction would cause a smaller magnitude
+    => Double/MAX_VALUE with same sign as start
+  If start is equal to +=Double/MAX_VALUE and direction would cause a larger magnitude
+    => ##Inf or ##-Inf with sign matching start
+  See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#nextAfter-double-double-"
+   :added "1.11.10"}
+  [start direction]
+  ; Branch to descending case first as it is more costly than ascending
+  ; case due to start != 0.0f conditional.
+  (let [a (js/ArrayBuffer. 8)
+        f (js/Float64Array. a)
+        i (js/Uint32Array. a)]
+    (cond
+      (> start direction) (if-not (zero? start)
+                            (let [_ (aset f 0 start)
+                                  ht (aget i HI)
+                                  lt (aget i LO)
+                                  ;; ht&lt != 0 since start != 0.0
+                                  ;; So long as the top bit is not set, then whole number is > 0
+                                  [hr lr] (if (zero? (bit-and ht INT32-NON-SIGN-BIT))
+                                            (add64 ht lt 0xFFFFFFFF 0xFFFFFFFF)
+                                            (add64 ht lt 0 1))]
+                              (aset i HI hr)
+                              (aset i LO lr)
+                              (aget f 0))
+                            ;; start == 0.0 && direction < 0.0
+                            (- js/Number.MIN_VALUE))
+      ;; Add +0.0 to get rid of a -0.0 (+0.0 + -0.0 => +0.0)
+      ;; then bitwise convert start to integer
+      (< start direction) (let [_ (aset f 0 (+ start 0.0))
+                                ht (aget i HI)
+                                lt (aget i LO)
+                                [hr lr] (if (zero? (bit-and ht INT32-NON-SIGN-BIT))
+                                          (add64 ht lt 0 1)
+                                          (add64 ht lt 0xFFFFFFFF 0xFFFFFFFF))]
+                            (aset i HI hr)
+                            (aset i LO lr)
+                            (aget f 0))
+      (== start direction) direction
+      :default (+ start direction))))  ;; isNaN(start) || isNaN(direction)
+
+(defn ^number next-up
+  {:doc "Returns the adjacent double of d in the direction of ##Inf.
+  If d is ##NaN => ##NaN
+  If d is ##Inf => ##Inf
+  If d is zero => Double/MIN_VALUE
+  See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#nextUp-double-"
+   :added "1.11.10"}
+  [d]
+  ;; Use a single conditional and handle the likely cases first
+  (if (< d js/Number.POSITIVE_INFINITY)
+    (let [a (js/ArrayBuffer. 8)
+          f (js/Float64Array. a)
+          i (js/Uint32Array. a)
+          ;; Add +0.0 to get rid of a -0.0 (+0.0 + -0.0 => +0.0)
+          _ (aset f 0 (+ d 0.0))
+          ht (aget i HI)
+          lt (aget i LO)
+          [hr lr] (if (zero? (bit-and ht INT32-NON-SIGN-BIT))
+                    (add64 ht lt 0 1)
+                    (add64 ht lt 0xFFFFFFFF 0xFFFFFFFF))]
+      (aset i HI hr)
+      (aset i LO lr)
+      (aget f 0))
+    ;; d is NaN or +Infinity
+    d))
+
+(defn ^number next-down
+  {:doc "Returns the adjacent double of d in the direction of ##-Inf.
+  If d is ##NaN => ##NaN
+  If d is ##Inf => Double/MAX_VALUE
+  If d is zero => -Double/MIN_VALUE
+  See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#nextDown-double-"
+   :added "1.11.10"}
+  [d]
+  (cond
+    (or ^boolean (js/isNaN d) (== ##-Inf d)) d
+    (zero? d) (- js/Number.MIN_VALUE)
+    :default
+    (let [a (js/ArrayBuffer. 8)
+          f (js/Float64Array. a)
+          i (js/Uint32Array. a)
+          _ (aset f 0 d)
+          ht (aget i HI)
+          lt (aget i LO)
+          [hr lr] (if (> d 0)
+                    (add64 ht lt 0xFFFFFFFF 0xFFFFFFFF)
+                    (add64 ht lt 0 1))]
+      (aset i HI hr)
+      (aset i LO lr)
+      (aget f 0))))
+
+(def ^:private MAX_SCALE (+ EXP-MAX (- EXP-MIN) SIGNIFICAND-WIDTH32 32 1))
+
+(def ^:private two-to-the-double-scale-up (power-of-two 512))
+
+(def ^:private two-to-the-double-scale-down (power-of-two -512))
+
+(defn ^number scalb
+  {:doc "Returns d * 2^scaleFactor, scaling by a factor of 2. If the exponent
+  is between Double/MIN_EXPONENT and Double/MAX_EXPONENT, the answer is exact.
+  scaleFactor is an integer
+  If d is ##NaN => ##NaN
+  If d is ##Inf or ##-Inf => ##Inf or ##-Inf respectively
+  If d is zero => zero of same sign as d
+  See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#nextDown-double-"
+   :added "1.11.10"}
+  [d scaleFactor]
+  (let [[scale-factor
+         scale-increment
+         exp-delta] (if (< scaleFactor 0)
+                      [(Math/max scaleFactor (- MAX_SCALE)) -512 two-to-the-double-scale-down]
+                      [(Math/min scaleFactor MAX_SCALE) 512 two-to-the-double-scale-up])
+        ;; Calculate (scaleFactor % +/-512), 512 = 2^9
+        ;; technique from "Hacker's Delight" section 10-2
+        t (unsigned-bit-shift-right (bit-shift-right scale-factor 8) 23)
+        exp-adjust (- (bit-and (+ scale-factor t) 511) t)]
+    (loop [d (* d (power-of-two exp-adjust)) scale-factor (- scale-factor exp-adjust)]
+      (if (zero? scale-factor)
+        d
+        (recur (* d exp-delta) (- scale-factor scale-increment))))))

--- a/src/main/cljs/cljs/math.cljs
+++ b/src/main/cljs/cljs/math.cljs
@@ -598,8 +598,8 @@
 
 (defn ^number get-exponent
   {:doc "Returns the exponent of d.
-  If d is ##NaN, ##Inf, ##-Inf => Double/MAX_EXPONENT + 1
-  If d is zero or subnormal => Double/MIN_EXPONENT - 1
+  If d is ##NaN, ##Inf, ##-Inf => max_Float64_exponent + 1
+  If d is zero or subnormal => min_Float64_exponent - 1
   See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#getExponent-double-"
    :added "1.11.10"}
   [d]
@@ -637,8 +637,8 @@
   {:doc "Returns the size of an ulp (unit in last place) for d.
   If d is ##NaN => ##NaN
   If d is ##Inf or ##-Inf => ##Inf
-  If d is zero => Double/MIN_VALUE
-  If d is +/- Double/MAX_VALUE => 2^971
+  If d is zero => Number/MIN_VALUE
+  If d is +/- Number/MAX_VALUE => 2^971
   See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#ulp-double-"
    :added "1.11.10"}
   [d]
@@ -744,11 +744,11 @@
   the second argument. If the arguments are equal, the second is returned.
   If either arg is #NaN => #NaN
   If both arguments are signed zeros => direction
-  If start is +-Double/MIN_VALUE and direction would cause a smaller magnitude
+  If start is +-Number/MIN_VALUE and direction would cause a smaller magnitude
     => zero with sign matching start
   If start is ##Inf or ##-Inf and direction would cause a smaller magnitude
-    => Double/MAX_VALUE with same sign as start
-  If start is equal to +=Double/MAX_VALUE and direction would cause a larger magnitude
+    => Number/MAX_VALUE with same sign as start
+  If start is equal to +=Number/MAX_VALUE and direction would cause a larger magnitude
     => ##Inf or ##-Inf with sign matching start
   See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#nextAfter-double-double-"
    :added "1.11.10"}
@@ -791,7 +791,7 @@
   {:doc "Returns the adjacent double of d in the direction of ##Inf.
   If d is ##NaN => ##NaN
   If d is ##Inf => ##Inf
-  If d is zero => Double/MIN_VALUE
+  If d is zero => Number/MIN_VALUE
   See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#nextUp-double-"
    :added "1.11.10"}
   [d]
@@ -816,8 +816,8 @@
 (defn ^number next-down
   {:doc "Returns the adjacent double of d in the direction of ##-Inf.
   If d is ##NaN => ##NaN
-  If d is ##Inf => Double/MAX_VALUE
-  If d is zero => -Double/MIN_VALUE
+  If d is ##Inf => Number/MAX_VALUE
+  If d is zero => -Number/MIN_VALUE
   See: https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#nextDown-double-"
    :added "1.11.10"}
   [d]
@@ -846,7 +846,7 @@
 
 (defn ^number scalb
   {:doc "Returns d * 2^scaleFactor, scaling by a factor of 2. If the exponent
-  is between Double/MIN_EXPONENT and Double/MAX_EXPONENT, the answer is exact.
+  is between min_Float64_exponent and max_Float64_exponent.
   scaleFactor is an integer
   If d is ##NaN => ##NaN
   If d is ##Inf or ##-Inf => ##Inf or ##-Inf respectively

--- a/src/test/cljs/clojure/gen_math_test.clj
+++ b/src/test/cljs/clojure/gen_math_test.clj
@@ -1,0 +1,285 @@
+(ns ^{:doc "Tests clojure.math to compare between JVM provided functions and the
+      clojure.math implementations on a ClojureScript instance running on NodeJS.
+      Tests are generative, but not run through the defspec framework to minimize
+      i/o to the ClojureScript instance."
+      :authors ["Michiel Borkent" "Paula Gearon"]}
+    clojure.gen-math-test
+    (:require [cljs.core.server]
+              [cljs.repl.node]
+              [clojure.core.server :as server]
+              [clojure.edn :as edn]
+              [clojure.java.io :as io]
+              [clojure.test :as t :refer [deftest is]]
+              [clojure.test.check.clojure-test :refer [defspec]]
+              [clojure.test.check.generators :as gen]
+              [clojure.test.check.properties :as prop]))
+
+(def ^:const Number-MAX_SAFE_INTEGER  9007199254740991)
+(def ^:const Number-MIN_SAFE_INTEGER -9007199254740991)
+(defn Number-isSafeInteger
+  [n]
+  (and (>= n Number-MIN_SAFE_INTEGER)
+       (<= n Number-MAX_SAFE_INTEGER)))
+
+(def gen-small-integer
+  "Generates a positive or negative integer bounded by the generator's
+  `size` parameter. Shrinks to zero."
+  (gen/sized (fn [size] (gen/choose (- size) size))))
+
+(def reader (atom nil))
+(def writer (atom nil))
+
+(defn cljs-eval [expr]
+  (-> (binding [*out* @writer
+                *in* @reader]
+        (println expr)
+        (read-line))
+      edn/read-string
+      :val))
+
+(t/use-fixtures :once
+  (fn [f]
+    (println "Launching test pREPL.")
+    (let [server (server/start-server {:accept 'cljs.core.server/io-prepl
+                                       :address "127.0.0.1"
+                                       :port 0
+                                       :name "clojure.math-repl"
+                                       :args [:repl-env (cljs.repl.node/repl-env)]})
+          port (-> server (.getLocalPort))]
+      (println "Server opened on port" port)
+      (with-open [socket (java.net.Socket. "127.0.0.1" port)
+                  rdr (io/reader socket)
+                  wrtr (io/writer socket)]
+        (reset! reader rdr)
+        (reset! writer wrtr)
+        (println "Executing tests")
+        (cljs-eval "(require 'clojure.math)")
+        (f)
+        (println "Tearing down test pREPL.")))))
+
+(deftest sanity-test
+  (is (= "6" (cljs-eval "(+ 1 2 3)"))))
+
+(deftest cljs-match-sanity-test
+  (is (= "1" (cljs-eval "(clojure.math/cos 0.0)"))))
+
+(defn n==
+  [a b]
+  (or (and (Double/isNaN a) (Double/isNaN b))
+      (and (number? a) (number? b) (== a b))
+      (= a b)))
+
+(defn maxi==
+  [a b]
+  (or (and (Double/isNaN a) (Double/isNaN b))
+      (and (= a Number-MAX_SAFE_INTEGER) (= b Long/MAX_VALUE))
+      (and (= a Number-MIN_SAFE_INTEGER) (= b Long/MIN_VALUE))
+      (and (number? a) (number? b) (== a b))
+      (= a b)))
+
+(defmacro test-t->t
+  [n jfn cfn gen & [equals]]
+  (let [jmfn (symbol "Math" (str jfn))
+        cmfn (name cfn)
+        eq (or equals n==)]
+    `(let [ds# (gen/sample ~gen ~n)]
+       (is (every? identity
+            (map ~eq
+                 (read-string
+                  (cljs-eval (str "(->> '" (pr-str ds#)
+                                  " (map double)"
+                                  " (map clojure.math/" ~cmfn "))")))
+                 (map #(~jmfn %) ds#)))
+           (str "data: " (pr-str ds#))))))
+
+(defmacro test-double->double
+  [n jfn cfn & [equals]]
+  `(test-t->t ~n ~jfn ~cfn gen/double ~equals))
+
+(defmacro test-t-t->double
+  [n jfn cfn gen1 gen2 & [equals]]
+  (let [jmfn (symbol "Math" (str jfn))
+        cmfn (name cfn)
+        eq (or equals n==)]
+    `(let [ds# (gen/sample ~gen1 ~n)
+           ds2# (gen/sample ~gen2 ~n)]
+       (is (every? identity
+            (map ~eq
+                 (read-string
+                  (cljs-eval (str "(->> (map #(vector %1 %2) '"
+                                  (pr-str ds#) " '" (pr-str ds2#) ")"
+                                  " (map #(try (apply clojure.math/" ~cmfn " %) (catch :default _ :exception))))")))
+                 (map #(~jmfn %1 %2) ds# ds2#)))
+           (str "data: " (pr-str (map vector ds# ds2#)))))))
+
+(defmacro test-double-double->double
+  [n jfn cfn & [equals]]
+  `(test-t-t->double ~n ~jfn ~cfn gen/double gen/double ~equals))
+
+(def safe-integer (gen/sized (fn [_] (gen/choose Number-MIN_SAFE_INTEGER Number-MAX_SAFE_INTEGER))))
+
+(defn e==
+  [a b]
+  (or (and (number? a) (number? b) (== a b))
+      (= a b)))
+
+(defmacro test-zlong-long->long
+  [n jfn cfn]
+  (let [jmfn (symbol "Math" (str jfn))
+        cmfn (name cfn)]
+    `(let [lzs# (gen/sample safe-integer ~n)
+           ls# (gen/sample (gen/such-that #(not= % 0) safe-integer) ~n)]
+       (is (every? identity
+            (map e==
+                 (read-string
+                  (cljs-eval (str "(->> (map #(vector (long %1) (long %2)) '"
+                                  (pr-str lzs#) " '" (pr-str ls#) ")"
+                                  " (map #(try (apply clojure.math/" ~cmfn " %) (catch :default _ :exception))))")))
+                 (map #(~jmfn (long %1) (long %2)) lzs# ls#)))
+           (str "data: " (pr-str (map vector lzs# ls#)))))))
+
+;; Tests clojure.core/abs. This function has recently moved to core
+(deftest abs-test
+  (let [ds (gen/sample gen/double 100)]
+    (is (every? identity
+                (map #(or (= (double %1) %2) (and (Double/isNaN %1) (Double/isNaN %2)))
+                     (read-string (cljs-eval (str "(->> '" (pr-str ds)
+                                                  " (map double)"
+                                                  " (map abs))")))
+                     (map #(Math/abs %) ds)))  ;; This can change to clojure.core/math after Clojure 11
+        (str "data: " (pr-str ds)))))
+
+(def ^:const delta 1E-15)
+
+(defn nd==
+  [label a b]
+  (or (and (Double/isNaN a) (Double/isNaN b))
+      (== a b)
+      (do
+        (println label "variance:" a "\u2260" b)
+        (< (Math/abs (- a b)) delta))))
+
+(deftest sin-test
+  (test-double->double 100 sin sin #(nd== "sin()" %1 %2)))
+
+(deftest to-radians-test
+  (test-double->double 100 toRadians to-radians))
+
+(deftest to-degrees-test
+  (test-double->double 100 toDegrees to-degrees))
+
+(deftest ieee-remainder-test
+  (test-double-double->double 100 IEEEremainder IEEE-remainder))
+
+(deftest ceil-test
+  (test-double->double 100 ceil ceil))
+
+(deftest ceil-null-test
+  (is (= ":exception" (cljs-eval (str "(try (clojure.math/ceil nil) (catch :default _ :exception))")))))
+
+(deftest floor-test
+  (test-double->double 100 floor floor))
+
+(deftest floor-null-test
+  (is (= ":exception" (cljs-eval (str "(try (clojure.math/floor nil) (catch :default _ :exception))")))))
+
+(deftest copy-sign-test
+  (test-double-double->double 100 copySign copy-sign))
+
+(deftest rint-test
+  (test-double->double 100 rint rint))
+
+(deftest round-test
+  (test-t->t 100 round round (gen/double* {:min Number-MIN_SAFE_INTEGER :max Number-MAX_SAFE_INTEGER}) maxi==))
+
+(deftest floor-div-test
+  (test-zlong-long->long 100 floorDiv floor-div))
+
+(deftest floor-mod-test
+  (test-zlong-long->long 100 floorMod floor-mod))
+
+(deftest get-exponent-test
+  (test-double->double 100 getExponent get-exponent))
+
+(deftest ulp-test
+  (test-double->double 100 ulp ulp))
+
+(deftest signum-test
+  (test-double->double 100 signum signum))
+
+(deftest next-after-test
+  (test-double-double->double 100 nextAfter next-after))
+
+(deftest next-up-test
+  (test-double->double 100 nextUp next-up))
+
+(deftest next-down-test
+  (test-double->double 100 nextDown next-down))
+
+(def ^:const MAX-INT 0x7fffffff)
+
+(deftest scalb-test
+  (test-t-t->double 100 scalb scalb
+                    gen/double
+                    (gen/such-that
+                     #(<= % MAX-INT)
+                     (gen/resize (inc MAX-INT) gen-small-integer))))
+
+;; utililties for the -exact tests
+(def safe-integer (gen/choose Number-MIN_SAFE_INTEGER Number-MAX_SAFE_INTEGER))
+
+(defn no-overflow?
+  [f ^long x ^long y]
+  (try
+    (Number-isSafeInteger (f x y))
+    (catch ArithmeticException _ false)))
+
+(defmacro test-safe-safe->safe
+  [n jfn cfn op]
+  (let [jmfn (symbol "Math" (str jfn))
+        cmfn (name cfn)]
+    `(let [ls1# (gen/sample safe-integer ~n)
+           ls2# (gen/sample safe-integer ~n)]
+       (is (every? identity
+                   (map e==
+                        (read-string
+                         (cljs-eval (str "(->> (map #(vector (long %1) (long %2)) '"
+                                         (pr-str ls1#) " '" (pr-str ls2#) ")"
+                                         " (map (fn [[a b]]"
+                                         "        (try (clojure.math/" ~cmfn "  a b)"
+                                         "          (catch :default _ :exception)))))")))
+                        (map #(if (no-overflow? ~op %1 %2)
+                                (~jmfn (long %1) (long %2))
+                                :exception) ls1# ls2#)))
+           (str "data: " (pr-str (map vector ls1# ls2#)))))))
+
+(deftest add-exact-test
+  (test-safe-safe->safe 100 addExact add-exact +))
+
+(deftest subtract-exact
+  (test-safe-safe->safe 100 subtractExact subtract-exact -))
+
+(deftest multiply-exact
+  (test-safe-safe->safe 100 multiplyExact multiply-exact *))
+
+(defmacro test-safe->safe
+  [n jfn cfn op]
+  (let [jmfn (symbol "Math" (str jfn))
+        cmfn (name cfn)]
+    `(let [ls# (gen/sample safe-integer ~n)]
+       (is (every? identity
+                   (map e==
+                        (read-string
+                         (cljs-eval (str "(->> '" (pr-str ls#)
+                                         " (map #(try (clojure.math/" ~cmfn " %)"
+                                         "         (catch :default _ :exception))))")))
+                        (map #(if (no-overflow? ~op % 1)
+                                (~jmfn (long %))
+                                :exception) ls#)))
+           (str "data: " (pr-str (map vector ls#)))))))
+
+(deftest increment-exact
+  (test-safe->safe 100 incrementExact increment-exact +))
+
+(deftest decrement-exact
+  (test-safe->safe 100 decrementExact decrement-exact -))

--- a/src/test/cljs/clojure/math_test.cljs
+++ b/src/test/cljs/clojure/math_test.cljs
@@ -1,0 +1,318 @@
+;   Copyright (c) Rich Hickey. All rights reserved.
+;   The use and distribution terms for this software are covered by the
+;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;   which can be found in the file epl-v10.html at the root of this distribution.
+;   By using this software in any fashion, you are agreeing to be bound by
+;   the terms of this license.
+;   You must not remove this notice, or any other, from this software.
+
+(ns clojure.math-test
+  (:require
+    [clojure.test :refer [deftest is]]
+    [cljs.math :as m]))
+
+(defn neg-zero?
+  [d]
+  (and (zero? d) (== -1.0 (m/copy-sign 1.0 d))))
+
+(defn pos-zero?
+  [d]
+  (and (zero? d) (== 1.0 (m/copy-sign 1.0 d))))
+
+(defn ulp=
+  "Tests that y = x +/- m*ulp(x)"
+  [x y m]
+  (let [mu (* (m/ulp x) m)]
+    (<= (- x mu) y (+ x mu))))
+
+(deftest test-sin
+  (is (js/isNaN (m/sin ##NaN)))
+  (is (js/isNaN (m/sin ##-Inf)))
+  (is (js/isNaN (m/sin ##Inf)))
+  (is (pos-zero? (m/sin 0.0)))
+  (is (neg-zero? (m/sin -0.0)))
+  (is (ulp= (m/sin m/PI) (- (m/sin (- m/PI))) 1)))
+
+(deftest test-cos
+  (is (js/isNaN (m/cos ##NaN)))
+  (is (js/isNaN (m/cos ##-Inf)))
+  (is (js/isNaN (m/cos ##Inf)))
+  (is (= 1.0 (m/cos 0.0) (m/cos -0.0)))
+  (is (ulp= (m/cos m/PI) (m/cos (- m/PI)) 1)))
+
+(deftest test-tan
+  (is (js/isNaN (m/tan ##NaN)))
+  (is (js/isNaN (m/tan ##-Inf)))
+  (is (js/isNaN (m/tan ##Inf)))
+  (is (pos-zero? (m/tan 0.0)))
+  (is (neg-zero? (m/tan -0.0)))
+  (is (ulp= (- (m/tan m/PI)) (m/tan (- m/PI)) 1)))
+
+(deftest test-asin
+  (is (js/isNaN (m/asin ##NaN)))
+  (is (js/isNaN (m/asin 2.0)))
+  (is (js/isNaN (m/asin -2.0)))
+  (is (zero? (m/asin -0.0))))
+
+(deftest test-acos
+  (is (js/isNaN (m/acos ##NaN)))
+  (is (js/isNaN (m/acos -2.0)))
+  (is (js/isNaN (m/acos 2.0)))
+  (is (ulp= (* 2 (m/acos 0.0)) m/PI 1)))
+
+(deftest test-atan
+  (is (js/isNaN (m/atan ##NaN)))
+  (is (pos-zero? (m/atan 0.0)))
+  (is (neg-zero? (m/atan -0.0)))
+  (is (ulp= (m/atan 1) 0.7853981633974483 1)))
+
+(deftest test-radians-degrees-roundtrip
+  (doseq [d (range 0.0 360.0 5.0)]
+    (is (ulp= (m/round d) (m/round (-> d m/to-radians m/to-degrees)) 1))))
+
+(deftest test-exp
+  (is (js/isNaN (m/exp ##NaN)))
+  (is (= ##Inf (m/exp ##Inf)))
+  (is (pos-zero? (m/exp ##-Inf)))
+  (is (ulp= (m/exp 0.0) 1.0 1))
+  (is (ulp= (m/exp 1) m/E 1)))
+
+(deftest test-log
+  (is (js/isNaN (m/log ##NaN)))
+  (is (js/isNaN (m/log -1.0)))
+  (is (= ##Inf (m/log ##Inf)))
+  (is (= ##-Inf (m/log 0.0)))
+  (is (ulp= (m/log m/E) 1.0 1)))
+
+(deftest test-log10
+  (is (js/isNaN (m/log10 ##NaN)))
+  (is (js/isNaN (m/log10 -1.0)))
+  (is (= ##Inf (m/log10 ##Inf)))
+  (is (= ##-Inf (m/log10 0.0)))
+  (is (ulp= (m/log10 10) 1.0 1)))
+
+(deftest test-sqrt
+  (is (js/isNaN (m/sqrt ##NaN)))
+  (is (js/isNaN (m/sqrt -1.0)))
+  (is (= ##Inf (m/sqrt ##Inf)))
+  (is (pos-zero? (m/sqrt 0)))
+  (is (= (m/sqrt 4.0) 2.0)))
+
+(deftest test-cbrt
+  (is (js/isNaN (m/cbrt ##NaN)))
+  (is (= ##-Inf (m/cbrt ##-Inf)))
+  (is (= ##Inf (m/cbrt ##Inf)))
+  (is (pos-zero? (m/cbrt 0)))
+  (is (= 2.0 (m/cbrt 8.0))))
+
+(deftest test-IEEE-remainder
+  (is (js/isNaN (m/IEEE-remainder ##NaN 1.0)))
+  (is (js/isNaN (m/IEEE-remainder 1.0 ##NaN)))
+  (is (js/isNaN (m/IEEE-remainder ##Inf 2.0)))
+  (is (js/isNaN (m/IEEE-remainder ##-Inf 2.0)))
+  (is (js/isNaN (m/IEEE-remainder 2 0.0)))
+  (is (= 1.0 (m/IEEE-remainder 5.0 4.0))))
+
+(deftest test-ceil
+  (is (js/isNaN (m/ceil ##NaN)))
+  (is (= ##Inf (m/ceil ##Inf)))
+  (is (= ##-Inf (m/ceil ##-Inf)))
+  (is (= 4.0 (m/ceil m/PI))))
+
+(deftest test-floor
+  (is (js/isNaN (m/floor ##NaN)))
+  (is (= ##Inf (m/floor ##Inf)))
+  (is (= ##-Inf (m/floor ##-Inf)))
+  (is (= 3.0 (m/floor m/PI))))
+
+(deftest test-rint
+  (is (js/isNaN (m/rint ##NaN)))
+  (is (= ##Inf (m/rint ##Inf)))
+  (is (= ##-Inf (m/rint ##-Inf)))
+  (is (= 1.0 (m/rint 1.2)))
+  (is (neg-zero? (m/rint -0.01))))
+
+(deftest test-atan2
+  (is (js/isNaN (m/atan2 ##NaN 1.0)))
+  (is (js/isNaN (m/atan2 1.0 ##NaN)))
+  (is (pos-zero? (m/atan2 0.0 1.0)))
+  (is (neg-zero? (m/atan2 -0.0 1.0)))
+  (is (ulp= (m/atan2 0.0 -1.0) m/PI 2))
+  (is (ulp= (m/atan2 -0.0 -1.0) (- m/PI) 2))
+  (is (ulp= (* 2.0 (m/atan2 1.0 0.0)) m/PI 2))
+  (is (ulp= (* -2.0 (m/atan2 -1.0 0.0)) m/PI 2))
+  (is (ulp= (* 4.0 (m/atan2 ##Inf ##Inf)) m/PI 2))
+  (is (ulp= (/ (* 4.0 (m/atan2 ##Inf ##-Inf)) 3.0) m/PI 2))
+  (is (ulp= (* -4.0 (m/atan2 ##-Inf ##Inf)) m/PI 2))
+  (is (ulp= (/ (* -4.0 (m/atan2 ##-Inf ##-Inf)) 3.0) m/PI 2)))
+
+(deftest test-pow
+  (is (= 1.0 (m/pow 4.0 0.0)))
+  (is (= 1.0 (m/pow 4.0 -0.0)))
+  (is (= 4.2 (m/pow 4.2 1.0)))
+  (is (js/isNaN (m/pow 4.2 ##NaN)))
+  (is (js/isNaN (m/pow ##NaN 2.0)))
+  (is (= ##Inf (m/pow 2.0 ##Inf)))
+  (is (= ##Inf (m/pow 0.5 ##-Inf)))
+  (is (= 0.0 (m/pow 2.0 ##-Inf)))
+  (is (= 0.0 (m/pow 0.5 ##Inf)))
+  (is (js/isNaN (m/pow 1.0 ##Inf)))
+  (is (pos-zero? (m/pow 0.0 1.5)))
+  (is (pos-zero? (m/pow ##Inf -2.0)))
+  (is (= ##Inf (m/pow 0.0 -2.0)))
+  (is (= ##Inf (m/pow ##Inf 2.0)))
+  (is (pos-zero? (m/pow -0.0 1.5)))
+  (is (pos-zero? (m/pow ##-Inf -1.5)))
+  (is (neg-zero? (m/pow -0.0 3.0)))
+  (is (neg-zero? (m/pow ##-Inf -3.0)))
+  (is (= ##Inf (m/pow -0.0 -1.5)))
+  (is (= ##Inf (m/pow ##-Inf 2.5)))
+  (is (= ##-Inf (m/pow -0.0 -3.0)))
+  (is (= ##-Inf (m/pow ##-Inf 3.0)))
+  (is (= 4.0 (m/pow -2.0 2.0)))
+  (is (= -8.0 (m/pow -2.0 3.0)))
+  (is (= 8.0 (m/pow 2.0 3.0))))
+
+(deftest test-round
+  (is (= 0 (m/round ##NaN)))
+  (is (= js/Number.MIN_SAFE_INTEGER (m/round ##-Inf)))
+  (is (= js/Number.MAX_SAFE_INTEGER (m/round ##Inf)))
+  (is (= 4 (m/round 3.5))))
+
+(deftest test-add-exact
+  (try
+    (m/add-exact js/Number.MAX_SAFE_INTEGER 1)
+    (is false)
+    (catch ExceptionInfo _
+      (is true))))
+
+(deftest test-subtract-exact
+  (try
+    (m/subtract-exact js/Number.MIN_SAFE_INTEGER 1)
+    (is false)
+    (catch ExceptionInfo _
+      (is true))))
+
+(deftest test-multiply-exact
+  (try
+    (m/multiply-exact js/Number.MAX_SAFE_INTEGER 2)
+    (is false)
+    (catch ExceptionInfo _
+      (is true))))
+
+(deftest test-increment-exact
+  (try
+    (m/increment-exact js/Number.MAX_SAFE_INTEGER)
+    (is false)
+    (catch ExceptionInfo _
+      (is true))))
+
+(deftest test-decrement-exact
+  (try
+    (m/decrement-exact js/Number.MIN_SAFE_INTEGER)
+    (is false)
+    (catch ExceptionInfo _
+      (is true))))
+
+(deftest test-negate-exact
+  (is (= js/Number.MIN_SAFE_INTEGER (m/negate-exact js/Number.MAX_SAFE_INTEGER)))
+  (is (= js/Number.MAX_SAFE_INTEGER (m/negate-exact js/Number.MIN_SAFE_INTEGER))))
+
+(deftest test-floor-div
+  (is (= js/Number.MAX_SAFE_INTEGER (m/floor-div js/Number.MIN_SAFE_INTEGER -1)))
+  (is (= -1 (m/floor-div -2 5))))
+
+(deftest test-floor-mod
+  (is (= 3 (m/floor-mod -2 5))))
+
+(deftest test-ulp
+  (is (js/isNaN (m/ulp ##NaN)))
+  (is (= ##Inf (m/ulp ##Inf)))
+  (is (= ##Inf (m/ulp ##-Inf)))
+  (is (= js/Number.MIN_VALUE (m/ulp 0.0)))
+  (is (= (m/pow 2 971) (m/ulp js/Number.MAX_VALUE)))
+  (is (= (m/pow 2 971) (m/ulp (- js/Number.MAX_VALUE)))))
+
+(deftest test-signum
+  (is (js/isNaN (m/signum ##NaN)))
+  (is (zero? (m/signum 0.0)))
+  (is (zero? (m/signum -0.0)))
+  (is (= 1.0 (m/signum 42.0)))
+  (is (= -1.0 (m/signum -42.0))))
+
+(deftest test-sinh
+  (is (js/isNaN (m/sinh ##NaN)))
+  (is (= ##Inf (m/sinh ##Inf)))
+  (is (= ##-Inf (m/sinh ##-Inf)))
+  (is (= 0.0 (m/sinh 0.0))))
+
+(deftest test-cosh
+  (is (js/isNaN (m/cosh ##NaN)))
+  (is (= ##Inf (m/cosh ##Inf)))
+  (is (= ##Inf (m/cosh ##-Inf)))
+  (is (= 1.0 (m/cosh 0.0))))
+
+(deftest test-tanh
+  (is (js/isNaN (m/tanh ##NaN)))
+  (is (= 1.0 (m/tanh ##Inf)))
+  (is (= -1.0 (m/tanh ##-Inf)))
+  (is (= 0.0 (m/tanh 0.0))))
+
+(deftest test-hypot
+  (is (= ##Inf (m/hypot 1.0 ##Inf)))
+  (is (= ##Inf (m/hypot ##Inf 1.0)))
+  (is (js/isNaN (m/hypot ##NaN 1.0)))
+  (is (js/isNaN (m/hypot 1.0 ##NaN)))
+  (is (= 13.0 (m/hypot 5.0 12.0))))
+
+(deftest test-expm1
+  (is (js/isNaN (m/expm1 ##NaN)))
+  (is (= ##Inf (m/expm1 ##Inf)))
+  (is (= -1.0 (m/expm1 ##-Inf)))
+  (is (= 0.0 (m/expm1 0.0))))
+
+(deftest test-log1p
+  (is (js/isNaN (m/log1p ##NaN)))
+  (is (= ##Inf (m/log1p ##Inf)))
+  (is (= ##-Inf (m/log1p -1.0)))
+  (is (pos-zero? (m/log1p 0.0)))
+  (is (neg-zero? (m/log1p -0.0))))
+
+(deftest test-copy-sign
+  (is (= 1.0 (m/copy-sign 1.0 42.0)))
+  (is (= -1.0 (m/copy-sign 1.0 -42.0)))
+  (is (= -1.0 (m/copy-sign 1.0 ##-Inf))))
+
+(deftest test-get-exponent
+  (is (= (inc @#'cljs.math/EXP-MAX) (m/get-exponent ##NaN)))
+  (is (= (inc @#'cljs.math/EXP-MAX) (m/get-exponent ##Inf)))
+  (is (= (inc @#'cljs.math/EXP-MAX) (m/get-exponent ##-Inf)))
+  (is (= (dec @#'cljs.math/EXP-MIN) (m/get-exponent 0.0)))
+  (is (= 0 (m/get-exponent 1.0)))
+  (is (= 13 (m/get-exponent 12345.678))))
+
+(deftest test-next-after
+  (is (js/isNaN (m/next-after ##NaN 1)))
+  (is (js/isNaN (m/next-after 1 ##NaN)))
+  (is (pos-zero? (m/next-after 0.0 0.0)))
+  (is (neg-zero? (m/next-after -0.0 -0.0)))
+  (is (= js/Number.MAX_VALUE (m/next-after ##Inf 1.0)))
+  (is (pos-zero? (m/next-after js/Number.MIN_VALUE -1.0))))
+
+(deftest test-next-up
+  (is (js/isNaN (m/next-up ##NaN)))
+  (is (= ##Inf (m/next-up ##Inf)))
+  (is (= js/Number.MIN_VALUE (m/next-up 0.0))))
+
+(deftest test-next-down
+  (is (js/isNaN (m/next-down ##NaN)))
+  (is (= ##-Inf (m/next-down ##-Inf)))
+  (is (= (- js/Number.MIN_VALUE) (m/next-down 0.0))))
+
+(deftest test-scalb
+  (is (js/isNaN (m/scalb ##NaN 1)))
+  (is (= ##Inf (m/scalb ##Inf 1)))
+  (is (= ##-Inf (m/scalb ##-Inf 1)))
+  (is (pos-zero? (m/scalb 0.0 2)))
+  (is (neg-zero? (m/scalb -0.0 2)))
+  (is (= 32.0 (m/scalb 2.0 4))))

--- a/src/test/cljs/test_runner.cljs
+++ b/src/test/cljs/test_runner.cljs
@@ -26,6 +26,7 @@
             [clojure.datafy-test]
             [clojure.edn-test]
             [clojure.walk-test]
+            [clojure.math-test]
             [cljs.macro-test]
             [cljs.letfn-test]
             [foo.ns-shadow-test]
@@ -81,6 +82,7 @@
   'clojure.datafy-test
   'clojure.edn-test
   'clojure.walk-test
+  'clojure.math-test
   'cljs.letfn-test
   'cljs.reducers-test
   'cljs.binding-test

--- a/src/test/self/self_parity/test.cljs
+++ b/src/test/self/self_parity/test.cljs
@@ -286,6 +286,7 @@
                  [clojure.data-test]
                  [clojure.datafy-test]
                  [clojure.edn]
+                 [clojure.math-test]
                  [clojure.walk-test]
                  [cljs.macro-test]
                  [cljs.letfn-test]
@@ -335,6 +336,7 @@
              'clojure.data-test
              'clojure.datafy-test
              'clojure.edn
+             'clojure.math-test
              'clojure.walk-test
              'cljs.letfn-test
              'cljs.reducers-test


### PR DESCRIPTION
This introduces the cljs.math namespace and clojure.core/abs for
parity with Clojure 1.11.0-alpha4.
Also introduces clojure.math-tests, which is an equivalent sets of
ClojureScript tests to the associated tests in Clojure.
Also include the Clojure test clojure.gen-math-test to compare
all reimplemented functions between the JVM versions and the
equivalent function calls executed on a ClojureScript prepl.