### PR TITLE
Speed up random-uuid by generating 4 digits at a time

### DIFF
--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -11584,17 +11584,13 @@ reduces them without incurring seq initialization"
 (defn random-uuid
   "Returns a pseudo-randomly generated UUID instance (i.e. type 4)."
   []
-  (letfn [(hex [] (.toString (rand-int 16) 16))]
-    (let [rhex (.toString (bit-or 0x8 (bit-and 0x3 (rand-int 16))) 16)]
+  (letfn [(quad-hex [] (.toString (rand-int 65536) 16))]
+    (let [ver-tripple-hex (.toString (bit-or 0x4000 (bit-and 0x0fff (rand-int 65536))) 16)
+          res-tripple-hex (.toString (bit-or 0x8000 (bit-and 0x3fff (rand-int 65536))) 16)]
       (uuid
-        (str (hex) (hex) (hex) (hex)
-             (hex) (hex) (hex) (hex) "-"
-             (hex) (hex) (hex) (hex) "-"
-             "4"   (hex) (hex) (hex) "-"
-             rhex  (hex) (hex) (hex) "-"
-             (hex) (hex) (hex) (hex)
-             (hex) (hex) (hex) (hex)
-             (hex) (hex) (hex) (hex))))))
+        (str (quad-hex) (quad-hex) "-" (quad-hex) "-" 
+         ver-tripple-hex "-" res-tripple-hex "-"
+         (quad-hex) (quad-hex) (quad-hex))))))
 
 (defn uuid?
   "Return true if x is a UUID."

--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -11584,13 +11584,19 @@ reduces them without incurring seq initialization"
 (defn random-uuid
   "Returns a pseudo-randomly generated UUID instance (i.e. type 4)."
   []
-  (letfn [(quad-hex [] (.toString (rand-int 65536) 16))]
+  (letfn [(quad-hex []
+            (let [unpadded-hex (.toString (rand-int 65536) 16)]
+              (case (count unpadded-hex)
+                1 (str "000" unpadded-hex)
+                2 (str "00" unpadded-hex)
+                3 (str "0" unpadded-hex)
+                unpadded-hex)))]
     (let [ver-tripple-hex (.toString (bit-or 0x4000 (bit-and 0x0fff (rand-int 65536))) 16)
           res-tripple-hex (.toString (bit-or 0x8000 (bit-and 0x3fff (rand-int 65536))) 16)]
       (uuid
-        (str (quad-hex) (quad-hex) "-" (quad-hex) "-" 
-         ver-tripple-hex "-" res-tripple-hex "-"
-         (quad-hex) (quad-hex) (quad-hex))))))
+        (str (quad-hex) (quad-hex) "-" (quad-hex) "-"
+             ver-tripple-hex "-" res-tripple-hex "-"
+             (quad-hex) (quad-hex) (quad-hex))))))
 
 (defn uuid?
   "Return true if x is a UUID."


### PR DESCRIPTION
By generating four digits at a time we can observe more than 2x the performance.

This is in line with other projects, such as https://github.com/uuidjs/uuid/blob/main/src/v4.js even though the implementation was created independently.