### PR TITLE
CLJS-3286: ns form does not merge ns-info

### DIFF
--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -3270,7 +3270,7 @@
              :requires       requires
              :renames        (merge renames core-renames)
              :imports        imports}]
-        (swap! env/*compiler* update-in [::namespaces name] merge ns-info)
+        (swap! env/*compiler* update-in [::namespaces name] merge-ns-info ns-info env)
         (merge {:op      :ns
                 :env     env
                 :form    form

--- a/src/test/self/self_host/test.cljs
+++ b/src/test/self/self_host/test.cljs
@@ -871,7 +871,7 @@
           (is (== 1 value))
           (inc! l))))))
 
-#_(deftest test-ns-merge
+(deftest test-cljs-3286
   (async done
     (cljs/eval-str st
                    "(ns foo.bar (:require [bootstrap-test.core :refer [foo]]))


### PR DESCRIPTION
Use special merge-ns-info function for ns* and ns ops. Fixes cljs issue where calling ns would clobber existing bindings.