### PR TITLE
CLJS-3288: selfhost: *eval-fn* not bound for :js sources

### DIFF
--- a/src/main/cljs/cljs/js.cljs
+++ b/src/main/cljs/cljs/js.cljs
@@ -838,12 +838,12 @@
                         ns-name
                         (:def-emits-var opts))
                       (cb (try
-                            {:ns ns-name :value (*eval-fn* {:source (.toString sb)})}
+                            {:ns ns-name :value ((:*eval-fn* bound-vars) {:source (.toString sb)})}
                             (catch :default cause
                               (wrap-error (ana/error aenv "ERROR" cause)))))))))
               (let [src (with-out-str (comp/emit ast))]
                 (cb (try
-                      {:value (*eval-fn* {:source src})}
+                      {:value ((:*eval-fn* bound-vars) {:source src})}
                       (catch :default cause
                         (wrap-error (ana/error aenv "ERROR" cause)))))))))))))
 

--- a/src/test/self/self_host/test.cljs
+++ b/src/test/self/self_host/test.cljs
@@ -1592,6 +1592,31 @@
                    (is (some? error))
                    (inc! l))))))
 
+(deftest test-cljs-3288
+  (async done
+    (let [st (cljs/empty-state)
+          l (latch 2 done)
+          load (fn [_ cb] (js/setTimeout #(cb {:lang :js :source ""}) 0))]
+      (cljs/eval st
+                 '(require 'bootstrap-test.js-source)
+                 {:ns     'cljs.user
+                  :target :nodejs
+                  :eval   node-eval
+                  :load   load}
+                 (fn [{:as res :keys [error]}]
+                   (is (nil? error))
+                   (inc! l)))
+      (cljs/eval-str st
+                     "(require 'bootstrap-test.js-source)"
+                     nil
+                     {:ns     'cljs.user
+                      :target :nodejs
+                      :eval   node-eval
+                      :load   load}
+                     (fn [{:as res :keys [error]}]
+                       (is (nil? error))
+                       (inc! l))))))
+
 (defn -main [& args]
   (run-tests))
 


### PR DESCRIPTION
When *load-fn* returns asynchronously, the dynamic var *eval-fn* is no longer bound. For :clj sources it is then re-bound inside eval-str*, but nothing equivalent happens for :js sources, which leads to the error No eval-fn set. This patch reads :*eval-fn* from bound-vars.