### PR TITLE
CLJS-3367: Backward conflict test in prefer-method causes incorrect exception

### DIFF
--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -11490,7 +11490,7 @@ reduces them without incurring seq initialization"
         prefer-table method-cache cached-hierarchy default-dispatch-val)))
 
   (-prefer-method [mf dispatch-val-x dispatch-val-y]
-    (when (prefers* dispatch-val-x dispatch-val-y prefer-table)
+    (when (prefers* dispatch-val-y dispatch-val-x  prefer-table)
       (throw (js/Error. (str "Preference conflict in multimethod '" name "': " dispatch-val-y
                    " is already preferred to " dispatch-val-x))))
     (swap! prefer-table

--- a/src/test/cljs/cljs/core_test.cljs
+++ b/src/test/cljs/cljs/core_test.cljs
@@ -312,6 +312,16 @@
       (is (= :parent (multi-with-h :child)))
 )))
 
+(def tmph (make-hierarchy))
+(defmulti fooz (fn [a b] (keyword b)) :hierarchy #'tmph)
+(defmethod fooz :a [a b] a)
+(defmethod fooz :b [a b] b)
+(prefer-method fooz :a :b)
+
+(deftest test-cljs-3367-backward-conflict-prefers
+  (testing "CLJS-3367: Verify no backward conflict in prefer-method"
+    (is (some? (prefer-method fooz :a :b)))))
+
 (deftest test-transducers
   (testing "Testing transducers"
     (is (= (sequence (map inc) (array 1 2 3)) '(2 3 4)))


### PR DESCRIPTION
Reverse prefers* test arguments, add test case.