### PR TITLE
CLJS-3368: let binding can shadow globals, leading to strange behavior

### DIFF
--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -2385,6 +2385,8 @@
                 line (get-line name env)
                 col (get-col name env)
                 shadow (handle-symbol-local name (get-in env [:locals name]))
+                shadow (when (nil? shadow)
+                         (get-in env [:js-globals name]))
                 be {:name name
                     :line line
                     :column col

--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -2384,9 +2384,8 @@
           (let [init-expr (analyze-let-binding-init env init (cons {:params bes} *loop-lets*))
                 line (get-line name env)
                 col (get-col name env)
-                shadow (handle-symbol-local name (get-in env [:locals name]))
-                shadow (when (nil? shadow)
-                         (get-in env [:js-globals name]))
+                shadow (or (handle-symbol-local name (get-in env [:locals name]))
+                           (get-in env [:js-globals name]))
                 be {:name name
                     :line line
                     :column col

--- a/src/main/clojure/cljs/repl.cljc
+++ b/src/main/clojure/cljs/repl.cljc
@@ -1113,7 +1113,7 @@
                ana/*fn-invoke-direct* (and static-fns fn-invoke-direct)
                *repl-opts* opts]
        (try
-         (let [env {:context :expr :locals {}}
+         (let [env (assoc (ana/empty-env) :context :expr)
                special-fns (merge default-special-fns special-fns)
                is-special-fn? (set (keys special-fns))
                request-prompt (Object.)

--- a/src/test/clojure/cljs/compiler_tests.clj
+++ b/src/test/clojure/cljs/compiler_tests.clj
@@ -365,6 +365,14 @@
         ns-info (env/ensure (comp/emit-source input output "cljs" {}))]
     (is (= 'foo.foo (:ns ns-info)))))
 
+(deftest test-3368-global-shadowing
+  (testing "Let binding which use JS global names should get shadowed"
+    (let [code (env/with-compiler-env (env/default-compiler-env)
+                 (compile-form-seq
+                   '[(defn foo []
+                       (let [window js/window]
+                         window))]))]
+      (is (re-find #"window__\$1" code)))))
 
 ;; CLJS-1225
 


### PR DESCRIPTION
* check :js-globals for shadowing in analysis of let bindings
* use the standard analyzer context in the REPL
* add a compiler test