### PR TITLE
require cljs.vendor.bridge instead of using load

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Official web site: http://clojurescript.org
 
 ## Releases and dependency information ##
 
-Latest stable release: 1.11.51
+Latest stable release: 1.11.52
 
 * [All released versions](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.clojure%22%20AND%20a%3A%22clojurescript%22)
 
 [Leiningen](http://github.com/technomancy/leiningen/) dependency information:
 
 ```
-[org.clojure/clojurescript "1.11.51"]
+[org.clojure/clojurescript "1.11.52"]
 ```
 
 [Maven](http://maven.apache.org) dependency information:
@@ -22,7 +22,7 @@ Latest stable release: 1.11.51
 <dependency>
   <groupId>org.clojure</groupId>
   <artifactId>clojurescript</artifactId>
-  <version>1.11.51</version>
+  <version>1.11.52</version>
 </dependency>
 ```
 

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,9 @@
+## 1.11.52
+
+### Changes
+* use `require` instead of `load` for `cljs.vendor.bridge`, addresses issue
+  reported by Bruce Hauman wrt. Figwheel
+
 ## 1.11.51
 
 ### Changes

--- a/src/main/clojure/cljs/repl.cljc
+++ b/src/main/clojure/cljs/repl.cljc
@@ -1057,7 +1057,7 @@
   ;; bridge clojure.tools.reader to satisfy the old contract
   (when (and (find-ns 'clojure.tools.reader)
              (not (find-ns 'cljs.vendor.bridge)))
-    (clojure.core/load "vendor/bridge"))
+    (require 'cljs.vendor.bridge))
   (doseq [[unknown-opt suggested-opt] (util/unknown-opts (set (keys opts)) (set/union known-repl-opts cljsc/known-opts))]
     (when suggested-opt
       (println (str "WARNING: Unknown option '" unknown-opt "'. Did you mean '" suggested-opt "'?"))))


### PR DESCRIPTION
Switch to `require` from `load` for loading cljs.vendor.bridge, fixes Figwheel issue reported by Bruce Hauman