### PR TITLE
CLJS-3377: Objects created from required JS constructor are not poisoned

### DIFF
--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -2577,14 +2577,18 @@
        (warning :fn-arity env {:argc argc :ctor ctor}))
      {:env env :op :new :form form :class ctorexpr :args argexprs
       :children [:class :args]
-      :tag (let [name (-> ctorexpr :info :name)]
-             (or ('{js/Object object
-                    js/String string
-                    js/Array  array
-                    js/Number number
-                    js/Function function
-                    js/Boolean boolean} name)
-                 name))})))
+      :tag (let [tag (-> ctorexpr :info :tag)]
+             (if (js-tag? tag)
+               ;; some foreign thing, drop the prefix
+               'js
+               (let [name (-> ctorexpr :info :name)]
+                 (or ('{js/Object object
+                        js/String string
+                        js/Array array
+                        js/Number number
+                        js/Function function
+                        js/Boolean boolean} name)
+                   name))))})))
 
 (defmethod parse 'set!
   [_ env [_ target val alt :as form] _ _]

--- a/src/test/clojure/cljs/externs_infer_tests.clj
+++ b/src/test/clojure/cljs/externs_infer_tests.clj
@@ -433,6 +433,26 @@
                 "Object.onAuthStateChanged;"])
               res)))))
 
+(deftest test-cljs-3377
+  (testing "constructors from foreign libraries that used via `new` should propagate 'js hints"
+    (let [ws  (atom [])
+          res (infer-test-helper
+                {:js-dependency-index {"firebase" {:global-exports '{firebase Firebase}}}
+                 :forms '[(ns foo.core
+                            (:require [firebase :refer [GoogleAuthProvider]]))
+                          (def goog-provider
+                            (GoogleAuthProvider.))
+                          (.someMethod goog-provider)
+                          (.-someProperty goog-provider)]
+                 :warnings ws
+                 :warn true
+                 :with-core? false})]
+      (is (= (unsplit-lines
+               ["Object.GoogleAuthProvider;"
+                "Object.someMethod;"
+                "Object.someProperty;"])
+            res)))))
+
 (comment
   (binding [ana/*cljs-ns* ana/*cljs-ns*]
     (ana/no-warn


### PR DESCRIPTION
fix 'new analyzer case to return 'js if the tag of the constructor is 'js
add test case