### PR TITLE
CLJS-3369: Speed up random-uuid by generating 4 digits at a time

### DIFF
--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -11602,17 +11602,19 @@ reduces them without incurring seq initialization"
 (defn random-uuid
   "Returns a pseudo-randomly generated UUID instance (i.e. type 4)."
   []
-  (letfn [(hex [] (.toString (rand-int 16) 16))]
-    (let [rhex (.toString (bit-or 0x8 (bit-and 0x3 (rand-int 16))) 16)]
+  (letfn [(^string quad-hex []
+            (let [unpadded-hex ^string (.toString (rand-int 65536) 16)]
+              (case (count unpadded-hex)
+                1 (str "000" unpadded-hex)
+                2 (str "00" unpadded-hex)
+                3 (str "0" unpadded-hex)
+                unpadded-hex)))]
+    (let [ver-tripple-hex ^string (.toString (bit-or 0x4000 (bit-and 0x0fff (rand-int 65536))) 16)
+          res-tripple-hex ^string (.toString (bit-or 0x8000 (bit-and 0x3fff (rand-int 65536))) 16)]
       (uuid
-        (str (hex) (hex) (hex) (hex)
-             (hex) (hex) (hex) (hex) "-"
-             (hex) (hex) (hex) (hex) "-"
-             "4"   (hex) (hex) (hex) "-"
-             rhex  (hex) (hex) (hex) "-"
-             (hex) (hex) (hex) (hex)
-             (hex) (hex) (hex) (hex)
-             (hex) (hex) (hex) (hex))))))
+        (str (quad-hex) (quad-hex) "-" (quad-hex) "-"
+             ver-tripple-hex "-" res-tripple-hex "-"
+             (quad-hex) (quad-hex) (quad-hex))))))
 
 (defn uuid?
   "Return true if x is a UUID."


### PR DESCRIPTION
Thanks Mike Fikes and David Nolen for suggesting the ^string typehint. The speedup for (simple-benchmark [] (random-uuid) num), where num 1e5, 1e6 and 1e7 is respectively:

iterations:   1e5    1e6    1e7
current (ms): 161   1596  15649
patch (ms):    55    522   5193

So there is about 3x speedup.