### PR TITLE
CLJS-3394: Add ECMASCRIPT options for 2018-2021

### DIFF
--- a/src/main/clojure/cljs/closure.clj
+++ b/src/main/clojure/cljs/closure.clj
@@ -235,7 +235,8 @@
 
 (def lang-level
   [:ecmascript3 :ecmascript5 :ecmascript5-strict :ecmascript6 :ecmascript6-strict
-   :ecmascript-2015 :ecmascript-2016 :ecmascript-2017 :ecmascript-next
+   :ecmascript-2015 :ecmascript-2016 :ecmascript-2017 :ecmascript-2018
+   :ecmascript-2019 :ecmascript-2020 :ecmascript-2021 :ecmascript-next
    :no-transpile])
 
 (defn expand-lang-key [key]
@@ -252,6 +253,10 @@
     :ecmascript-2015       CompilerOptions$LanguageMode/ECMASCRIPT_2015
     :ecmascript-2016       CompilerOptions$LanguageMode/ECMASCRIPT_2016
     :ecmascript-2017       CompilerOptions$LanguageMode/ECMASCRIPT_2017
+    :ecmascript-2018       CompilerOptions$LanguageMode/ECMASCRIPT_2018
+    :ecmascript-2019       CompilerOptions$LanguageMode/ECMASCRIPT_2019
+    :ecmascript-2020       CompilerOptions$LanguageMode/ECMASCRIPT_2020
+    :ecmascript-2021       CompilerOptions$LanguageMode/ECMASCRIPT_2021
     :ecmascript-next       CompilerOptions$LanguageMode/ECMASCRIPT_NEXT))
 
 (defn set-options

--- a/src/main/clojure/cljs/compiler.cljc
+++ b/src/main/clojure/cljs/compiler.cljc
@@ -49,6 +49,7 @@
                 [lang (keyword (string/replace (name lang) #"^ecmascript" "es"))])))
     [:ecmascript5 :ecmascript5-strict :ecmascript6 :ecmascript6-strict
      :ecmascript-2015 :ecmascript6-typed :ecmascript-2016 :ecmascript-2017
+     :ecmascript-2018 :ecmascript-2019 :ecmascript-2020 :ecmascript-2021
      :ecmascript-next]))
 
 (def ^:dynamic *recompiled* nil)


### PR DESCRIPTION
This patch adds options for language levels ECMASCRIPT_2018, ECMASCRIPT_2019, ECMASCRIPT_2020, and ECMASCRIPT_2021, which are available in Closure Compiler.