### PR TITLE
Add deps.edn snippet to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Latest stable release: 1.11.60
 
 * [All released versions](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.clojure%22%20AND%20a%3A%22clojurescript%22)
 
+[Clojure deps.edn](http://clojure.org/guides/deps_and_cli) dependency information:
+
+```
+org.clojure/clojurescript {:mvn/version "1.11.60"}
+```
+
 [Leiningen](http://github.com/technomancy/leiningen/) dependency information:
 
 ```


### PR DESCRIPTION
Small detail. Every time I want to start a clojurescript project with deps.edn I come here looking for the latest version. Please give deps.edn equal standing in the clojurescipt README by adding this snippet that we can copy and paste :).

Feel free to copy the snippet into the code instead of merging.