### PR TITLE
Respect forms :line and :column meta when provided

### DIFF
--- a/src/main/clojure/cljs/vendor/clojure/tools/reader.clj
+++ b/src/main/clojure/cljs/vendor/clojure/tools/reader.clj
@@ -378,7 +378,7 @@
       (let [o (read* rdr true nil opts pending-forms)]
         (if (instance? IMeta o)
           (let [m (if (and line (seq? o))
-                    (assoc m :line line :column column)
+                    (merge {:line line :column column} m)
                     m)]
             (if (instance? IObj o)
               (with-meta o (merge (meta o) m))


### PR DESCRIPTION
There is currently a difference between Clojure and ClojureScript in how the readers handle the provided :line and :column meta for forms.

In Clojure:
```
Clojure 1.11.1
user=> ^{:line 40} (defn foo [])
#'user/foo
user=> (-> #'foo meta :line)
40
```
while in ClojureScript:
```
ClojureScript 1.11.60
cljs.user=> ^{:line 40} (defn foo [])
#'cljs.user/foo
cljs.user=> (-> #'foo meta :line)
1
```

This patch just gives precedence to the lines and columns provided by the user which allows tooling that are sending forms to the repl to set the correct line and column for the forms if they know them. This is specially important in ClojureScript where there isn't a way of modifying vars meta.

Since ClojureScript is distributing a vendored tools.reader probably this is a patch that should be submitted to the tools.reader project but trying here first to get directions.
