### PR TITLE
CLJS-3413: Macros not loaded w/ single segment namespace loaded via `:preloads`

### DIFF
--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -3957,6 +3957,7 @@
      :else
      (or (some-> env :ns :require-macros (get (symbol nstr)) #?(:clj  find-ns
                                                                 :cljs find-macros-ns))
+       ;; single segment namespace case
        #?(:clj  (find-ns (symbol nstr))
           :cljs (find-macros-ns (symbol nstr)))))))
 

--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -3954,8 +3954,11 @@
          :cljs [(identical? "clojure.repl" nstr) (find-macros-ns 'cljs.repl)])
      #?@(:clj  [(.contains nstr ".") (find-ns (symbol nstr))]
          :cljs [(goog.string/contains nstr ".") (find-macros-ns (symbol nstr))])
-     :else (some-> env :ns :require-macros (get (symbol nstr)) #?(:clj  find-ns
-                                                                  :cljs find-macros-ns)))))
+     :else
+     (or (some-> env :ns :require-macros (get (symbol nstr)) #?(:clj  find-ns
+                                                                :cljs find-macros-ns))
+       #?(:clj  (find-ns (symbol nstr))
+          :cljs (find-macros-ns (symbol nstr)))))))
 
 (defn get-expander* [sym env]
   (when-not (or (some? (gets env :locals sym)) ; locals hide macros

--- a/src/main/clojure/cljs/closure.clj
+++ b/src/main/clojure/cljs/closure.clj
@@ -3081,6 +3081,10 @@
                                     [(-compile (io/resource "cljs/nodejs.cljs")
                                        (assoc opts :output-file "nodejs.js"))]))
                                 deps/dependency-order
+                                ;; NOTE: :preloads are compiled *after*
+                                ;; user specified inputs. Thus user code cannot
+                                ;; depend on anything (i.e. fn/macros) defined
+                                ;; in preloads via global access pattern
                                 (add-preloads opts)
                                 remove-goog-base
                                 add-goog-base

--- a/src/test/cljs/cljs/macro_test.cljs
+++ b/src/test/cljs/cljs/macro_test.cljs
@@ -8,9 +8,10 @@
 
 (ns cljs.macro-test
   (:refer-clojure :exclude [==])
-  (:require [cljs.test :refer-macros [deftest is]])
+  (:require [cljs.test :as test :refer-macros [deftest is]])
   (:use-macros [cljs.macro-test.macros :only [== sm-cljs-3027]])
-  (:require-macros [cljs.macro-test.cljs2852]))
+  (:require-macros [cljs.macro-test.cljs2852]
+                   [single-seg-macros]))
 
 (deftest test-macros
   (is (= (== 1 1) 2)))
@@ -31,3 +32,6 @@
 
 (deftest test-cljs-3027
   (is (= {"a" "b"} (sm-cljs-3027))))
+
+(deftest test-cljs-3413
+  (is (= 5 (single-seg-macros/test-macro 2 3))))

--- a/src/test/cljs/single_seg_macros.clj
+++ b/src/test/cljs/single_seg_macros.clj
@@ -1,0 +1,4 @@
+(ns single-seg-macros)
+
+(defmacro test-macro [a b]
+  `(+ ~a ~b))


### PR DESCRIPTION
See https://clojure.atlassian.net/jira/software/c/projects/CLJS/issues?jql=project%20%3D%20%22CLJS%22%20ORDER%20BY%20created%20DESC