### PR TITLE
Add support for the Bun and pnpm package managers.

### DIFF
--- a/src/main/clojure/cljs/cli.clj
+++ b/src/main/clojure/cljs/cli.clj
@@ -638,7 +638,7 @@ generic - the combinations must be explicitly supported"}
                                 :doc (str "Set the output directory to use. If "
                                        "supplied, cljsc_opts.edn in that directory "
                                        "will be used to set ClojureScript compiler "
-                                       "options") }
+                                       "options")}
       ["-w" "--watch"]         {:group ::compile :fn watch-opt
                                 :arg "paths"
                                 :doc (str "Continuously build, only effective with the "
@@ -649,7 +649,7 @@ generic - the combinations must be explicitly supported"}
                                 :doc "Set the output compiled file"}
       ["--deps-cmd"]           {:group ::compile :fn deps-cmd-opt
                                 :arg "string"
-                                :doc "Set the node dependency manager. Only npm or yarn supported"}
+                                :doc "Set the node dependency manager. Only npm, bun, pnpm, and yarn are supported"}
       ["-O" "--optimizations"] {:group ::compile :fn optimize-opt
                                 :arg "level"
                                 :doc
@@ -661,7 +661,7 @@ generic - the combinations must be explicitly supported"}
                                 :doc
                                 (str "The JavaScript target. Configures environment bootstrap and "
                                      "defaults to browser. Supported values: node or nodejs, "
-                                     "webworker, bundle, none") }
+                                     "webworker, bundle, none")}
       ["-ro" "--repl-opts"]    {:group ::main&compile :fn repl-env-opts-opt
                                 :arg "edn"
                                 :doc (str "Options to configure the repl-env, can be an EDN string or "

--- a/src/main/clojure/cljs/closure.clj
+++ b/src/main/clojure/cljs/closure.clj
@@ -2623,7 +2623,11 @@
         (let [proc (-> (ProcessBuilder.
                          (into (cond->>
                                  [deps-cmd
-                                  ({"npm" "install" "yarn" "add"} deps-cmd)
+                                  ({"npm" "install"
+                                    "bun" "add"
+                                    "pnpm" "add"
+                                    "yarn" "add"}
+                                   deps-cmd)
                                   "@cljs-oss/module-deps"]
                                  util/windows? (into ["cmd" "/c"]))
                            (map (fn [[dep version]] (str (name dep) "@" version)))
@@ -2667,7 +2671,9 @@
                 (string/replace "CLJS_TARGET" (str "" (when target (name target))))
                 (string/replace "MAIN_ENTRIES" main-entries)
                 (string/replace "FILE_SEPARATOR" (escape-backslashes File/separator)))
-         proc (-> (ProcessBuilder. ["node" "--eval" code])
+         proc (-> (ProcessBuilder. (case (:deps-cmd opts)
+                                     "bun" ["bun" "--eval" code]
+                                     ["node" "--eval" code]))
                 .start)
          is   (.getInputStream proc)
          iw   (StringWriter. (* 16 1024 1024))

--- a/src/test/clojure/cljs/foreign/node_test.clj
+++ b/src/test/clojure/cljs/foreign/node_test.clj
@@ -11,8 +11,8 @@
   ([f]
    (test-util/delete-node-modules)
    (doseq [f (map io/file
-               ["package.json" "package-lock.json" "yarn.lock"
-               "yarn-error.log"])]
+               ["package.json" "package-lock.json" "bun.lockb"
+                "pnpm-lock.yaml" "yarn.lock" "yarn-error.log"])]
      (when (.exists f)
        (io/delete-file f)))
    (f)))
@@ -21,7 +21,7 @@
   ([lib version]
    (install :npm lib version))
   ([cmd lib version]
-   (let [action ({:npm "install" :yarn "add"} cmd)]
+   (let [action ({:npm "install" :bun "add" :pnpm "add" :yarn "add"} cmd)]
      (sh/sh (name cmd) action (str lib "@" version)))))
 
 (test/use-fixtures :once cleanup)


### PR DESCRIPTION
## Description

Mirroring a similar contribution to shadow-cljs.

* Issue: https://github.com/thheller/shadow-cljs/issues/1196
* Pull Request: https://github.com/thheller/shadow-cljs/pull/1193

See the shadow-cljs issue for a more detailed "why".

This also adds support for `node_modules` indexing with the Bun runtime.

## Testing

I've avoided adding additional tests in `src/test/clojure/cljs/foreign/node_test.clj` for the time being since I'm not sure how the ClojureScript CI environment is configured (not sure if Bun and pnpm are available).

Instead, I created a test repository with a barebones CLJS project using the fork (sourced in `deps.edn` with the [`git` procurer](https://clojure.org/reference/deps_edn#deps_git)).

https://github.com/commiterate/test-clojurescript-bun

This repository uses [Emmy](https://github.com/mentat-collective/emmy) to create a Node.js application that just prints 2<sup>1</sup> (using Emmy's `exp2` function) to stdout.

A reproducible shell is provided with Nix for additional testing by the ClojureScript team and others.

---

There's notes in the test repository's readme detailing some sharp edges with:

* Using the ClojureScript compiler build API with `tools.build` (classpath issues breaking `deps.cljs` searches).
* Using the ClojureScript compiler CLI.

These might be of interest to the ClojureScript team for future improvements.