### PR TITLE
Remove pr-opts calls, backwards compatibility tweaks

### DIFF
--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -1568,6 +1568,7 @@
         :throw    impl/IGNORE_SYM
         :let      (infer-tag env (:body ast))
         :loop     (infer-tag env (:body ast))
+        :try      (infer-tag env (:body ast))
         :do       (infer-tag env (:ret ast))
         :fn-method (infer-tag env (:body ast))
         :def      (infer-tag env (:init ast))


### PR DESCRIPTION
* remove calls to pr-opts
  - just use dynamic binding
  - keep it backwards compatible