### PR TITLE
Use primitives in print-map

### DIFF
--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -10524,7 +10524,9 @@ reduces them without incurring seq initialization"
   (reify
     IMapEntry
     (-key [_] k)
-    (-val [_] v)))
+    (-val [_] v)
+    ISeqable
+    (-seq [_] (IndexedSeq. #js [k v] 0 nil))))
 
 (defn- pr-writer-impl
   [obj writer opts]


### PR DESCRIPTION
* lower print-map
  - lift pr-map-entry-helper
  - lift-ns uses array of MapEntry instead of actual map