### PR TITLE
CLJS-3439: REPL doc support for externs

### DIFF
--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -977,10 +977,13 @@
        (or (= 'js x)
            (= "js" (namespace x)))))
 
+(defn ->pre [x]
+  (->> (string/split (name x) #"\.") (map symbol)))
+
 (defn normalize-js-tag [x]
   ;; if not 'js, assume constructor
   (if-not (= 'js x)
-    (let [props  (->> (string/split (name x) #"\.") (map symbol))
+    (let [props  (->pre x)
           [xs y] ((juxt butlast last) props)]
       (with-meta 'js
         {:prefix (vec (concat xs [(with-meta y {:ctor true})]))}))

--- a/src/main/clojure/cljs/analyzer/api.cljc
+++ b/src/main/clojure/cljs/analyzer/api.cljc
@@ -218,6 +218,15 @@
   ([state]
    (keys (get @state ::ana/namespaces))))
 
+(defn resolve-extern
+  "Given a symbol attempt to look it up in the provided externs"
+  ([sym]
+   (resolve-extern env/*compiler* sym))
+  ([state sym]
+   (let [pre (ana/->pre sym)]
+     (env/with-compiler-env state
+       (:info (ana/resolve-extern pre))))))
+
 (defn find-ns
   "Given a namespace return the corresponding namespace analysis map. Analagous
   to clojure.core/find-ns."

--- a/src/main/clojure/cljs/repl.cljc
+++ b/src/main/clojure/cljs/repl.cljc
@@ -1447,6 +1447,11 @@ itself (not its value) is returned. The reader macro #'x expands to (var x)."}})
               (keyword? name)
               `(cljs.repl/print-doc {:spec ~name :doc (cljs.spec.alpha/describe ~name)})
 
+              (= "js" (namespace name))
+              `(cljs.repl/print-doc
+                 (quote ~(merge (select-keys (ana-api/resolve-extern name) [:doc :arglists])
+                           {:name name})))
+
               (ana-api/find-ns name)
               `(cljs.repl/print-doc
                  (quote ~(select-keys (ana-api/find-ns name) [:name :doc])))


### PR DESCRIPTION
* break out ->pre
* add cljs.analyzer.api/resolve-extern
* new doc lookup path in repl for js/foo symbols