### PR TITLE
CLJS-3233: `:refer-global` + `:only`, `:require-global`

### DIFF
--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -3551,7 +3551,8 @@
                                         (partial use->require env))
                       :use-macros     (comp (partial parse-require-spec env true deps aliases)
                                         (partial use->require env))
-                      :import         (partial parse-import-spec env deps)}
+                      :import         (partial parse-import-spec env deps)
+                      :require-global #(parse-global-require-spec env env/*compiler* deps aliases %)}
         reload       (atom {:use nil :require nil :use-macros nil :require-macros nil})
         reloads      (atom {})
         {uses :use requires :require renames :rename

--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -3063,14 +3063,17 @@
 
       (== cnt 1)
       (let [[_ & {:keys [only rename] :as parsed-spec}] (first xs)
-            err-str "Only (:refer-global :only [names]) and optionally `:rename {from to}` specs supported"]
+            only-set (set only)
+            err-str "Only (:refer-global :only [names]) and optionally `:rename {from to}` specs supported.
+ :rename symbols must be present in :only"]
         (when-not (or (empty? only)
                       (and (vector? only)
                            (every? symbol only)))
           (throw (error env err-str)))
         (when-not (or (empty? rename)
                       (and (map? rename)
-                           (every? symbol (mapcat identity rename))))
+                           (every? symbol (mapcat identity rename))
+                           (every? only-set (keys rename))))
           (throw (error env (str err-str (pr-str parsed-spec)))))
         (when-not (every? #{:only :rename} (keys parsed-spec))
           (throw (error env (str err-str (pr-str parsed-spec)))))

--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -3129,7 +3129,7 @@
                             (when-not (some #{original} referred)
                               (throw (error env
                                        (str "Renamed symbol " original " not referred"))))
-                            (assoc m renamed (symbol "js " (str (str lib) "." (str original)))))
+                            (assoc m renamed (symbol "js" (str (str lib) "." (str original)))))
                     {} renamed)}))))))
 
 (defn parse-require-spec [env macros? deps aliases spec]

--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -3084,9 +3084,9 @@
                    rename)}))))
 
 (defn parse-global-require-spec
-  [env deps aliases spec]
+  [env aliases spec]
   (if (or (symbol? spec) (string? spec))
-    (recur env deps aliases [spec])
+    (recur env aliases [spec])
     (do
       (basic-validate-ns-spec env false spec)
       (let [[lib & opts] spec
@@ -3117,7 +3117,6 @@
             (error env
               (parse-ns-error-msg spec
                 ":refer must be followed by a sequence of symbols in :require / :require-macros"))))
-        (swap! deps conj lib)
         (merge
           (when (some? alias)
             {rk (merge {alias lib} {lib lib})})

--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -3082,7 +3082,8 @@
                    (map (fn [[orig new-name]]
                           [new-name (symbol "js" (str orig))]))
                    rename)}))))
-(defn js-lib [lib]
+
+(defn global-lib [lib]
   (symbol "js" (str lib)))
 
 (defn parse-global-require-spec
@@ -3121,9 +3122,9 @@
                 ":refer must be followed by a sequence of symbols in :require / :require-macros"))))
         (merge
           (when (some? alias)
-            {rk (merge {alias (js-lib lib)} {lib (js-lib lib)})})
+            {rk (merge {alias (global-lib lib)} {lib (global-lib lib)})})
           (when (some? referred-without-renamed)
-            {uk (apply hash-map (interleave referred-without-renamed (repeat (js-lib lib))))})
+            {uk (apply hash-map (interleave referred-without-renamed (repeat (global-lib lib))))})
           (when (some? renamed)
             {renk (reduce (fn [m [original renamed]]
                             (when-not (some #{original} referred)

--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -2821,12 +2821,14 @@
                             (error-message :undeclared-ns {:ns-sym dep :js-provide (name dep)}))))))))))))
 
 (defn missing-use? [lib sym cenv]
-  (let [js-lib (get-in cenv [:js-dependency-index (name lib)])]
-    (and (= (get-in cenv [::namespaces lib :defs sym] ::not-found) ::not-found)
-         (not (= (get js-lib :group) :goog))
-         (not (get js-lib :closure-lib))
-         (not (node-module-dep? lib))
-         (not (dep-has-global-exports? lib)))))
+  ;; ignore globals referred via :refer-global
+  (when-not (= 'js lib)
+    (let [js-lib (get-in cenv [:js-dependency-index (name lib)])]
+      (and (= (get-in cenv [::namespaces lib :defs sym] ::not-found) ::not-found)
+        (not (= (get js-lib :group) :goog))
+        (not (get js-lib :closure-lib))
+        (not (node-module-dep? lib))
+        (not (dep-has-global-exports? lib))))))
 
 (defn missing-rename? [sym cenv]
   (let [lib (symbol (namespace sym))

--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -3436,7 +3436,7 @@
                                           (partial use->require env))
                         :import         (partial parse-import-spec env deps)
                         :require-global #(parse-global-require-spec env aliases %)}
-          valid-forms  (atom #{:use :use-macros :require :require-macros :import})
+          valid-forms  (atom #{:use :use-macros :require :require-macros :require-global :import})
           reload       (atom {:use nil :require nil :use-macros nil :require-macros nil})
           reloads      (atom {})
           {uses :use requires :require renames :rename

--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -3372,7 +3372,6 @@
                         :use-macros     (comp (partial parse-require-spec env true deps aliases)
                                           (partial use->require env))
                         :import         (partial parse-import-spec env deps)
-                        ;:refer-global   (partial parse-global-refer-spec env)
                         ;:require-global #(parse-global-require-spec env deps aliases %)
                         }
           valid-forms  (atom #{:use :use-macros :require :require-macros :import})
@@ -3401,7 +3400,7 @@
               (apply merge-with merge m
                 (map (spec-parsers k)
                   (remove #{:reload :reload-all} libs))))
-            {} (remove (fn [[r]] (= r :refer-clojure)) args))
+            {} (remove (fn [[r]] (#{:refer-clojure :refer-global} r)) args))
           ;; patch `require-macros` and `use-macros` in Bootstrap for namespaces
           ;; that require their own macros
           #?@(:cljs [[require-macros use-macros]

--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -3465,6 +3465,7 @@
         core-renames (reduce (fn [m [original renamed]]
                                (assoc m renamed (symbol "cljs.core" (str original))))
                        {} core-renames)
+        {global-uses :use global-renames :rename} (parse-global-refer-spec env args)
         deps         (atom [])
         ;; as-aliases can only be used *once* because they are about the reader
         aliases      (atom {:fns as-aliases :macros as-aliases})
@@ -3495,7 +3496,7 @@
             (apply merge-with merge m
               (map (spec-parsers k)
                 (remove #{:reload :reload-all} libs))))
-          {} (remove (fn [[r]] (= r :refer-clojure)) args))]
+          {} (remove (fn [[r]] (#{:refer-clojure :refer-global} r)) args))]
     (set! *cljs-ns* name)
     (let [require-info
           {:as-aliases     as-aliases
@@ -3504,9 +3505,9 @@
            :use-macros     use-macros
            :require-macros require-macros
            :rename-macros  rename-macros
-           :uses           uses
+           :uses           (merge uses global-uses)
            :requires       requires
-           :renames        (merge renames core-renames)
+           :renames        (merge renames core-renames global-renames)
            :imports        imports}]
       (swap! env/*compiler* update-in [::namespaces name] merge-ns-info require-info env)
       (merge {:op      :ns*

--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -2820,9 +2820,13 @@
                           (error env
                             (error-message :undeclared-ns {:ns-sym dep :js-provide (name dep)}))))))))))))
 
+(defn global-ns? [x]
+  (or (= 'js x)
+      (= "js" (namespace x))))
+
 (defn missing-use? [lib sym cenv]
   ;; ignore globals referred via :refer-global
-  (when-not (= 'js lib)
+  (when-not (global-ns? lib)
     (let [js-lib (get-in cenv [:js-dependency-index (name lib)])]
       (and (= (get-in cenv [::namespaces lib :defs sym] ::not-found) ::not-found)
         (not (= (get js-lib :group) :goog))

--- a/src/main/clojure/cljs/closure.clj
+++ b/src/main/clojure/cljs/closure.clj
@@ -1608,7 +1608,11 @@
          "], ["
          ;; even under Node.js where runtime require is possible
          ;; this is necessary - see CLJS-2151
-         (ns-list (cond->> (deps/-requires input)
+         (ns-list (cond->>
+                      ;; remove external? foreign deps - they are already loaded
+                      ;; in the environment, there is nothing to do.
+                      ;; :require-global is the typical case here
+                      (remove ana/external-dep? (deps/-requires input))
                     ;; under Node.js we emit native `require`s for these
                     (= :nodejs (:target opts))
                     (filter (complement ana/node-module-dep?))))

--- a/src/main/clojure/cljs/closure.clj
+++ b/src/main/clojure/cljs/closure.clj
@@ -1127,13 +1127,17 @@
   (let [requires    (set (mapcat deps/-requires inputs))
         required-js (js-dependencies opts requires)]
     (concat
-      (map
-        (fn [{:keys [foreign url file provides requires] :as js-map}]
-          (let [url (or url (io/resource file))]
-            (merge
-              (javascript-file foreign url provides requires)
-              js-map)))
-        required-js)
+      (->> required-js
+        ;; :foreign-libs which declare :external? have no sources (they are included
+        ;; on the page via some script tag we'll never see). :require-global libs are
+        ;; implicit :foreign-libs where :external? is true
+        (remove :external?)
+        (map
+          (fn [{:keys [foreign url file provides requires] :as js-map}]
+            (let [url (or url (io/resource file))]
+              (merge
+                (javascript-file foreign url provides requires)
+                js-map)))))
       (when (-> @env/*compiler* :options :emit-constants)
         [(constants-javascript-file opts)])
       inputs)))

--- a/src/main/clojure/cljs/compiler.cljc
+++ b/src/main/clojure/cljs/compiler.cljc
@@ -1367,7 +1367,10 @@
                          escape-string
                          wrap-in-double-quotes)
                        ");"))
-                   (emitln "goog.require('" (munge lib) "');"))))]
+                   (if-not (ana/external-dep? lib)
+                     (emitln "goog.require('" (munge lib) "');")
+                     ;; TODO: validate the lib exists
+                     ))))]
             :cljs
             [(and (ana/foreign-dep? lib)
                   (not (keyword-identical? optimizations :none)))

--- a/src/main/clojure/cljs/core.cljc
+++ b/src/main/clojure/cljs/core.cljc
@@ -3128,6 +3128,13 @@
   [& args]
   `(~'ns* ~(cons :refer-global args)))
 
+(core/defmacro require-global
+  "Require libraries in the global JS environment.
+
+  (require-global '[SomeLib :as lib :refer [foo]])"
+  [& args]
+  `(~'ns* ~(cons :require-global args)))
+
 ;; INTERNAL - do not use, only for Node.js
 (core/defmacro load-file* [f]
   `(goog/nodeGlobalRequire ~f))

--- a/src/main/clojure/cljs/core.cljc
+++ b/src/main/clojure/cljs/core.cljc
@@ -12,7 +12,7 @@
                             defprotocol defrecord defstruct deftype delay destructure doseq dosync dotimes doto
                             extend-protocol extend-type fn for future gen-class gen-interface
                             if-let if-not import io! lazy-cat lazy-seq let letfn locking loop
-                            memfn ns or proxy proxy-super pvalues refer-clojure reify sync time
+                            memfn ns or proxy proxy-super pvalues reify sync time
                             when when-first when-let when-not while with-bindings with-in-str
                             with-loading-context with-local-vars with-open with-out-str with-precision with-redefs
                             satisfies? identical? true? false? number? nil? instance? symbol? keyword? string? str get

--- a/src/main/clojure/cljs/core.cljc
+++ b/src/main/clojure/cljs/core.cljc
@@ -3116,6 +3116,13 @@
   [& args]
   `(~'ns* ~(cons :refer-clojure args)))
 
+(core/defmacro refer-global
+  "Refer global js vars. Supports renaming via :rename.
+
+  (refer-global :only '[Date Symbol] :rename '{Symbol Sym})"
+  [& args]
+  `(~'ns* ~(cons :refer-global args)))
+
 ;; INTERNAL - do not use, only for Node.js
 (core/defmacro load-file* [f]
   `(goog/nodeGlobalRequire ~f))

--- a/src/main/clojure/cljs/repl.cljc
+++ b/src/main/clojure/cljs/repl.cljc
@@ -251,10 +251,6 @@
      (load-sources repl-env sources opts)
      sources)))
 
-(defn global-ns? [x]
-  (or (= 'js x)
-      (= "js" (namespace x))))
-
 (defn- load-dependencies
   "Compile and load the given `requires` and return the compiled sources."
   ([repl-env requires]
@@ -262,7 +258,7 @@
   ([repl-env requires opts]
    (->> requires
      distinct
-     (remove global-ns?)
+     (remove ana/global-ns?)
      (mapcat #(load-namespace repl-env % opts))
      doall)))
 

--- a/src/main/clojure/cljs/repl.cljc
+++ b/src/main/clojure/cljs/repl.cljc
@@ -259,6 +259,7 @@
    (->> requires
      distinct
      (remove ana/global-ns?)
+     (remove ana/external-dep?)
      (mapcat #(load-namespace repl-env % opts))
      doall)))
 
@@ -656,7 +657,7 @@
 (defn- wrap-fn [form]
   (cond
     (and (seq? form)
-         (#{'ns 'require 'require-macros 'refer-global
+         (#{'ns 'require 'require-macros 'refer-global 'require-global
             'use 'use-macros 'import 'refer-clojure} (first form)))
     identity
 

--- a/src/test/clojure/cljs/analyzer_tests.clj
+++ b/src/test/clojure/cljs/analyzer_tests.clj
@@ -394,6 +394,14 @@
            '{:use {Date js Symbol js}
              :rename {JSSymbol js/Symbol}}))))
 
+(deftest test-parse-require-global
+  (let [parsed (ana/parse-global-require-spec {} (atom {:fns {}})
+                '[React :refer [createElement] :as react])]
+    (is (= parsed
+           '{:require {react js/React
+                       React js/React}
+             :use {createElement js/React}}))))
+
 (deftest test-cljs-1785-js-shadowed-by-local
   (let [ws (atom [])]
     (ana/with-warning-handlers [(collecting-warning-handler ws)]

--- a/src/test/clojure/cljs/analyzer_tests.clj
+++ b/src/test/clojure/cljs/analyzer_tests.clj
@@ -395,18 +395,23 @@
              :rename {JSSymbol js/Symbol}}))))
 
 (deftest test-parse-require-global
-  (let [parsed (ana/parse-global-require-spec {} (atom {:fns {}})
-                '[React :refer [createElement] :as react])]
+  (let [cenv   (atom {})
+        deps   (atom [])
+        parsed (ana/parse-global-require-spec {} cenv deps (atom {:fns {}}) 
+                 '[React :refer [createElement] :as react])]
+    (println (pr-str @cenv) (pr-str @deps))
     (is (= parsed
-          '{:require {react js/React
-                      React js/React}
-            :use  {createElement js/React}})))
-  (let [parsed (ana/parse-global-require-spec {} (atom {:fns {}})
-                '[React :refer [createElement] :rename {createElement create} :as react])]
+          '{:require {react React
+                      React React}
+            :use  {createElement React}})))
+  (let [cenv   (atom {})
+        deps   (atom [])
+        parsed (ana/parse-global-require-spec {} cenv deps (atom {:fns {}})
+                 '[React :refer [createElement] :rename {createElement create} :as react])]
     (is (= parsed
-          '{:require {react js/React
-                      React js/React}
-            :rename  {create js/React.createElement}}))))
+          '{:require {react React
+                      React React}
+            :rename  {create React/createElement}}))))
 
 (deftest test-cljs-1785-js-shadowed-by-local
   (let [ws (atom [])]
@@ -1582,7 +1587,7 @@
                         '(ns foo.core
                            (:require-global [React :as react :refer [createElement]]))))]
       (is (= (:requires parsed-ns)
-             '{React js/React
-               react js/React}))
+             '{React React
+               react React}))
       (is (= (:uses parsed-ns)
-             '{createElement js/React})))))
+             '{createElement React})))))

--- a/src/test/clojure/cljs/analyzer_tests.clj
+++ b/src/test/clojure/cljs/analyzer_tests.clj
@@ -389,9 +389,9 @@
 
 (deftest test-parse-global-refer
   (let [parsed (ana/parse-global-refer-spec {}
-                '((:refer-global :only [Date] :rename {Symbol JSSymbol})))]
+                '((:refer-global :only [Date Symbol] :rename {Symbol JSSymbol})))]
     (is (= parsed
-           '{:use {Date js}
+           '{:use {Date js Symbol js}
              :rename {JSSymbol js/Symbol}}))))
 
 (deftest test-cljs-1785-js-shadowed-by-local

--- a/src/test/clojure/cljs/analyzer_tests.clj
+++ b/src/test/clojure/cljs/analyzer_tests.clj
@@ -398,9 +398,15 @@
   (let [parsed (ana/parse-global-require-spec {} (atom {:fns {}})
                 '[React :refer [createElement] :as react])]
     (is (= parsed
-           '{:require {react js/React
-                       React js/React}
-             :use {createElement js/React}}))))
+          '{:require {react js/React
+                      React js/React}
+            :use  {createElement js/React}})))
+  (let [parsed (ana/parse-global-require-spec {} (atom {:fns {}})
+                '[React :refer [createElement] :rename {createElement create} :as react])]
+    (is (= parsed
+          '{:require {react js/React
+                      React js/React}
+            :rename  {create js/React.createElement}}))))
 
 (deftest test-cljs-1785-js-shadowed-by-local
   (let [ws (atom [])]

--- a/src/test/clojure/cljs/analyzer_tests.clj
+++ b/src/test/clojure/cljs/analyzer_tests.clj
@@ -389,7 +389,7 @@
 
 (deftest test-parse-global-refer
   (let [parsed (ana/parse-global-refer-spec {}
-                '((:refer-global [Date] :rename {Symbol JSSymbol})))]
+                '((:refer-global :only [Date] :rename {Symbol JSSymbol})))]
     (is (= parsed
            '{:use {Date js}
              :rename {JSSymbol js/Symbol}}))))

--- a/src/test/clojure/cljs/analyzer_tests.clj
+++ b/src/test/clojure/cljs/analyzer_tests.clj
@@ -556,9 +556,11 @@
 
 (deftest test-analyze-refer-global
   (testing "refer-global macro expr return expected AST"
-    (let [test-env (ana/empty-env)]
-      (is (= (-> (analyze test-env '(refer-global :only '[Date])) :uses vals set)
-            '#{js})))))
+    (binding [ana/*cljs-ns* ana/*cljs-ns*
+              ana/*cljs-warnings* nil]
+      (let [test-env (ana/empty-env)]
+        (is (= (-> (analyze test-env '(refer-global :only '[Date])) :uses vals set)
+              '#{js}))))))
 
 (deftest test-gen-user-ns
   ;; note: can't use `with-redefs` because direct-linking is enabled

--- a/src/test/clojure/cljs/analyzer_tests.clj
+++ b/src/test/clojure/cljs/analyzer_tests.clj
@@ -171,7 +171,7 @@
           (analyze ns-env '(ns foo.bar (:unless [])))
           (catch Exception e
             (.getMessage (.getCause e))))
-        "Only :refer-clojure, :require, :require-macros, :use, :use-macros, and :import libspecs supported. Got (:unless []) instead."))
+        "Only :refer-clojure, :require, :require-macros, :use, :use-macros, :require-global and :import libspecs supported. Got (:unless []) instead."))
   (is (.startsWith
         (try
           (analyze ns-env '(ns foo.bar (:require baz.woz) (:require noz.goz)))

--- a/src/test/clojure/cljs/analyzer_tests.clj
+++ b/src/test/clojure/cljs/analyzer_tests.clj
@@ -1566,16 +1566,11 @@
 ;; -----------------------------------------------------------------------------
 ;; :refer-global / :require-global ns parsing tests
 
-#_(deftest test-refer-global
+(deftest test-refer-global
   (binding [ana/*cljs-ns* ana/*cljs-ns*]
     (let [parsed-ns (env/with-compiler-env test-cenv
                       (analyze test-env
                         '(ns foo.core
-                           (:refer-global [Date] :rename {Date MyDate}))))]
-      )))
-
-(comment
-
-  (clojure.test/test-vars [#'test-refer-global])
-
-  )
+                           (:refer-global :only [Date] :rename {Date MyDate}))))]
+      (= (:renames parsed-ns)
+         '{MyDate js/Date}))))

--- a/src/test/clojure/cljs/analyzer_tests.clj
+++ b/src/test/clojure/cljs/analyzer_tests.clj
@@ -387,6 +387,13 @@
             :renames  {map clj-map}}))
     (is (set? (:excludes parsed)))))
 
+(deftest test-parse-global-refer
+  (let [parsed (ana/parse-global-refer-spec {}
+                '((:refer-global [Date] :rename {Symbol JSSymbol})))]
+    (is (= parsed
+           '{:use {Date js}
+             :rename {JSSymbol js/Symbol}}))))
+
 (deftest test-cljs-1785-js-shadowed-by-local
   (let [ws (atom [])]
     (ana/with-warning-handlers [(collecting-warning-handler ws)]

--- a/src/test/clojure/cljs/analyzer_tests.clj
+++ b/src/test/clojure/cljs/analyzer_tests.clj
@@ -1533,3 +1533,20 @@
             (ana/gen-constant-id '+)))
   (is (not= (ana/gen-constant-id 'foo.bar)
             (ana/gen-constant-id 'foo$bar))))
+
+;; -----------------------------------------------------------------------------
+;; :refer-global / :require-global ns parsing tests
+
+#_(deftest test-refer-global
+  (binding [ana/*cljs-ns* ana/*cljs-ns*]
+    (let [parsed-ns (env/with-compiler-env test-cenv
+                      (analyze test-env
+                        '(ns foo.core
+                           (:refer-global [Date] :rename {Date MyDate}))))]
+      )))
+
+(comment
+
+  (clojure.test/test-vars [#'test-refer-global])
+
+  )

--- a/src/test/clojure/cljs/analyzer_tests.clj
+++ b/src/test/clojure/cljs/analyzer_tests.clj
@@ -1574,3 +1574,15 @@
                            (:refer-global :only [Date] :rename {Date MyDate}))))]
       (= (:renames parsed-ns)
          '{MyDate js/Date}))))
+
+(deftest test-require-global
+  (binding [ana/*cljs-ns* ana/*cljs-ns*]
+    (let [parsed-ns (env/with-compiler-env test-cenv
+                      (analyze test-env
+                        '(ns foo.core
+                           (:require-global [React :as react :refer [createElement]]))))]
+      (is (= (:requires parsed-ns)
+             '{React js/React
+               react js/React}))
+      (is (= (:uses parsed-ns)
+             '{createElement js/React})))))

--- a/src/test/clojure/cljs/analyzer_tests.clj
+++ b/src/test/clojure/cljs/analyzer_tests.clj
@@ -554,6 +554,12 @@
         (analyze test-env
           '(map #(require '[clojure.set :as set]) [1 2]))))))
 
+(deftest test-analyze-refer-global
+  (testing "refer-global macro expr return expected AST"
+    (let [test-env (ana/empty-env)]
+      (is (= (-> (analyze test-env '(refer-global :only '[Date])) :uses vals set)
+            '#{js})))))
+
 (deftest test-gen-user-ns
   ;; note: can't use `with-redefs` because direct-linking is enabled
   (let [s   "src/cljs/foo.cljs"


### PR DESCRIPTION
- [x] fix `test-parse-global-refer`, can only `:rename` if in `:only`