### PR TITLE
CLJS-3461: don't hard-code destructuring to PAM

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,11 @@
   org.clojure/tools.reader {:mvn/version "1.3.6"}
   org.clojure/test.check {:mvn/version "1.1.1"}}
  :aliases
- {:cli.test.run          {:extra-paths ["src/test/cljs_cli"]
+ {:cljs-repl             {:extra-paths ["src/test/cljs"]
+                          :main-opts ["-m" "cljs.main" "-re" "node" "-d" ".cljs_repl" "-r"]}
+  :cljs-lite-repl        {:extra-paths ["src/test/cljs"]
+                          :main-opts ["-m" "cljs.main" "-co" "{:lite-mode true}" "-re" "node" "-d" ".cljs_lite_repl" "-r"]}
+  :cli.test.run          {:extra-paths ["src/test/cljs_cli"]
                           :main-opts ["-i" "src/test/cljs_cli/cljs_cli/test_runner.clj"
                                       "-e" "(cljs-cli.test-runner/-main)"]}
   :compiler.test         {:extra-paths ["src/test/cljs" "src/test/cljs_build" "src/test/cljs_cp"

--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -4129,7 +4129,7 @@ reduces them without incurring seq initialization"
 (defn --destructure-map [gmap]
   (if (implements? ISeq gmap)
     (if (next gmap)
-      (.createAsIfByAssoc (. {} -constructor) (to-array gmap))
+      (.createAsIfByAssoc (if ^boolean LITE_MODE ObjMap PersistentArrayMap) (to-array gmap))
       (if (seq gmap)
         (first gmap)
         {}))
@@ -9040,7 +9040,7 @@ reduces them without incurring seq initialization"
   https://clojure.org/reference/special_forms#keyword-arguments"
   [s]
   (if (next s)
-    (.createAsIfByAssoc (. {} -constructor) (to-array s))
+    (.createAsIfByAssoc (if ^boolean LITE_MODE ObjMap PersistentArrayMap) (to-array s))
     (if (seq s) (first s) {})))
 
 (defn sorted-map

--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -4129,13 +4129,21 @@ reduces them without incurring seq initialization"
 ;; CLJS-3200: used by destructure macro for maps to reduce amount of repeated code
 ;; placed here because it needs apply and hash-map (only declared at this point)
 (defn --destructure-map [gmap]
-  (if (implements? ISeq gmap)
-    (if (next gmap)
-      (.createAsIfByAssoc (if ^boolean LITE_MODE ObjMap PersistentArrayMap) (to-array gmap))
-      (if (seq gmap)
-        (first gmap)
-        {}))
-    gmap))
+  (if ^boolean LITE_MODE
+    (if (implements? ISeq gmap)
+      (if (next gmap)
+        (.createAsIfByAssoc ObjMap (to-array gmap))
+        (if (seq gmap)
+          (first gmap)
+          (.-EMPTY ObjMap)))
+      gmap)
+    (if (implements? ISeq gmap)
+      (if (next gmap)
+        (.createAsIfByAssoc PersistentArrayMap (to-array gmap))
+        (if (seq gmap)
+          (first gmap)
+          (.-EMPTY PersistentArrayMap)))
+      gmap)))
 
 (defn vary-meta
  "Returns an object of the same type and value as obj, with
@@ -9041,9 +9049,13 @@ reduces them without incurring seq initialization"
   "Builds a map from a seq as described in
   https://clojure.org/reference/special_forms#keyword-arguments"
   [s]
-  (if (next s)
-    (.createAsIfByAssoc (if ^boolean LITE_MODE ObjMap PersistentArrayMap) (to-array s))
-    (if (seq s) (first s) {})))
+  (if ^boolean LITE_MODE
+    (if (next s)
+      (.createAsIfByAssoc ObjMap (to-array s))
+      (if (seq s) (first s) (.-EMPTY ObjMap)))
+    (if (next s)
+      (.createAsIfByAssoc PersistentArrayMap (to-array s))
+      (if (seq s) (first s) (.-EMPTY PersistentArrayMap)))))
 
 (defn sorted-map
   "keyval => key val
@@ -12733,7 +12745,7 @@ reduces them without incurring seq initialization"
           (recur (nnext kvs)))
         (.fromObject ObjMap ks obj)))))
 
-(set! (.-createAsIfByAssoc ObjMap)
+(set! (. ObjMap -createAsIfByAssoc)
   (fn [init]
     ;; check trailing element
     (let [len           (alength init)

--- a/src/main/cljs/cljs/core.cljs
+++ b/src/main/cljs/cljs/core.cljs
@@ -4124,6 +4124,8 @@ reduces them without incurring seq initialization"
 
 (set! *unchecked-if* false)
 
+(declare ObjMap)
+
 ;; CLJS-3200: used by destructure macro for maps to reduce amount of repeated code
 ;; placed here because it needs apply and hash-map (only declared at this point)
 (defn --destructure-map [gmap]


### PR DESCRIPTION
- use empty map literal instead, use the constructor for createAsIfByAssoc
- perf is not critical for `:lite-mode` opt for simplicity for now
- add REPL aliases to deps.edn to make it easier to play around :lite-mode