### PR TITLE
cljs.proxy doesn't handle `for .. of` correctly

### DIFF
--- a/src/main/cljs/cljs/proxy.cljs
+++ b/src/main/cljs/cljs/proxy.cljs
@@ -82,7 +82,7 @@
          map-handler #js {:get (fn [^cljs.core/ILookup target prop receiver]
                                  (cond
                                    (identical? (. Symbol -iterator) prop)
-                                   (unchecked-get target prop)
+                                   (.bind (unchecked-get target prop) target)
 
                                    :else (js/__ctor (-lookup target (cache-key-fn prop)))))
 

--- a/src/main/cljs/cljs/proxy/impl.cljs
+++ b/src/main/cljs/cljs/proxy/impl.cljs
@@ -13,3 +13,12 @@
   (clear [this]
     (set! obj #js {})
     (set! cnt 0)))
+
+(deftype MapIterator [^:mutable iter f]
+  Object
+  (next [_]
+    (let [x (.next iter)]
+      (if-not ^boolean (. x -done)
+        #js {:value (f (. x -value))
+             :done  false}
+        x))))


### PR DESCRIPTION
- check for Symbol.iterator case in vec and map handler
- need to bind iterator to target for it to work
- fixes trivial vector case [1 2 3 4], but not nested case
  * will need to map over the results of the iterator
  * this true for the map case too where entries are 2-element arrays