### PR TITLE
CLJS-3475: Unexpected :as-alias error

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps
  {com.google.javascript/closure-compiler {:mvn/version "v20250820"}
   com.cognitect/transit-java {:mvn/version "1.0.362"}
-  org.clojure/clojure {:mvn/version "1.10.0"}
+  org.clojure/clojure {:mvn/version "1.11.4"}
   org.clojure/core.specs.alpha {:mvn/version "0.1.24"}
   org.clojure/google-closure-library {:mvn/version "0.0-20250515-f04e4c0e"}
   org.clojure/spec.alpha {:mvn/version "0.1.143"}

--- a/src/main/clojure/cljs/analyzer/impl/namespaces.cljc
+++ b/src/main/clojure/cljs/analyzer/impl/namespaces.cljc
@@ -30,10 +30,10 @@
 
 (defn check-as-alias-duplicates
   [as-aliases new-as-aliases]
-  (doseq [[alias _] new-as-aliases]
-    (assert (not (contains? as-aliases alias))
-      (str "Duplicate :as-alias " alias ", already in use for lib "
-        (get as-aliases alias)))))
+  (doseq [[alias new-lib] new-as-aliases]
+    (let [lib-in-use (get as-aliases alias)]
+      (assert (or (not lib-in-use) (= lib-in-use new-lib))
+        (str "Duplicate :as-alias " alias ", already in use for lib " lib-in-use)))))
 
 (defn elide-aliases-from-libspecs
   "Given libspecs, elide all :as-alias. Return a map of :libspecs (filtered)

--- a/src/test/cljs_build/cljs_3475_as_alias_duplicate/a_ns.cljc
+++ b/src/test/cljs_build/cljs_3475_as_alias_duplicate/a_ns.cljc
@@ -1,0 +1,6 @@
+(ns cljs-3475-as-alias-duplicate.a-ns
+  ; This line caused:
+  ;
+  ;  Assert failed: Duplicate :as-alias aliased-in, already in use for lib a-ns
+  #?(:cljs (:require-macros [cljs-3475-as-alias-duplicate.a-ns]))
+  (:require [cljs-3475-as-alias-duplicate.aliases-in-another-ns]))

--- a/src/test/cljs_build/cljs_3475_as_alias_duplicate/aliases_in_another_ns.cljc
+++ b/src/test/cljs_build/cljs_3475_as_alias_duplicate/aliases_in_another_ns.cljc
@@ -1,0 +1,2 @@
+(ns cljs-3475-as-alias-duplicate.aliases-in-another-ns
+  (:require [cljs-3475-as-alias-duplicate.a-ns :as-alias aliased-in]))

--- a/src/test/clojure/cljs/build_api_tests.clj
+++ b/src/test/clojure/cljs/build_api_tests.clj
@@ -941,6 +941,21 @@
       (test/delete-node-modules)
       (test/delete-out-files out))))
 
+(deftest test-cljs-3475-as-alias-duplicate
+  (testing "Test that using :as-alias in a :require-macro .cljc does not cause a duplicate alias"
+    (let [{:keys [major minor]} *clojure-version*
+          out      (.getPath (io/file (test/tmp-dir) "cljs-3475-as-alias-duplicate-out"))
+          out-file (io/file out "main.js")
+          {:keys [inputs opts]} {:inputs (str (io/file "src" "test" "cljs_build"))
+                                 :opts   {:main       'cljs-3475-as-alias-duplicate.a-ns
+                                          :output-dir out
+                                          :output-to  (.getPath out-file)}}
+          cenv     (env/default-compiler-env)]
+      (test/delete-out-files out)
+      (is (and (<= 1 major) (<= 11 minor)) "Clojure version too old - as-alias was introduced in Clojure 1.11: https://clojure.org/news/2022/03/22/clojure-1-11-0")
+      (build/build (build/inputs (io/file inputs "cljs_3475_as_alias_duplicate/a_ns.cljc"))
+        opts cenv))))
+
 #_(deftest test-cljs-3452-str-optimizations
   (testing "Test that uses compile time optimizations from str macro"
     (let [out (.getPath (io/file (test/tmp-dir) "cljs-3452-str-optimizations-out"))]


### PR DESCRIPTION
- `check-as-alias-duplicates` did not consider that the same lib can already be in use from the `:require-macro`
- 1.11 is a requirement, earlier versions will cause a cyclic load dependency