### PR TITLE
CLJS-3480: Browser REPL - (println "Expected:") breaks REPL

### DIFF
--- a/src/main/cljs/clojure/browser/repl.cljs
+++ b/src/main/cljs/clojure/browser/repl.cljs
@@ -49,7 +49,7 @@
   (garray/clear print-queue))
 
 (defn repl-print [data]
-  (.push print-queue (pr-str data))
+  (.push print-queue data)
   (when @parent-connected?
     (flush-print-queue! @xpc-connection)))
 

--- a/src/main/clojure/cljs/repl/browser.clj
+++ b/src/main/clojure/cljs/repl/browser.clj
@@ -306,9 +306,13 @@
   [{:keys [repl data order] :as _request-content} conn _]
   (constrain-order order
     (fn []
-      (binding [*out* (or (and repl (.get outs repl)) *out*)]
-        (print (edn/read-string data))
-        (.flush *out*))))
+      (try
+        (binding [*out* (or (and repl (.get outs repl)) *out*)]
+          (print data))
+        (catch Throwable t
+          (print t))
+        (finally
+          (.flush *out*)))))
   (server/send-and-close conn 200 "ignore__"))
 
 (defmethod handle-post :result


### PR DESCRIPTION
- remove the pr-str in clojure.browser/repl-print print etc will set *print-readably* to false, so this can't possibly be right. This appears to be vestigial from the early days of bREPL development
- in cljs.repl.browser/handle-post :print, drop edn/read-string the server really doesn't know anything about printing ClojureScript, it should just print the value given.
- running tests interactively in bREPL now behaves the same as under the Node.js REPL