### PR TITLE
CLJS-3481: support :error, :warning, :off modes with :warnings

### DIFF
--- a/src/main/clojure/cljs/analyzer.cljc
+++ b/src/main/clojure/cljs/analyzer.cljc
@@ -484,12 +484,17 @@
                    "ambiguous expression " form)))
 
 (defn default-warning-handler [warning-type env extra]
-  (when (warning-type *cljs-warnings*)
-    (when-let [s (error-message warning-type extra)]
-      #?(:clj  (binding [*out* *err*]
-                 (println (message env (str "WARNING: " s))))
-         :cljs (binding [*print-fn* *print-err-fn*]
-                 (println (message env (str "WARNING: " s))))))))
+  (let [warn-mode (warning-type *cljs-warnings*)]
+    (when-not (#{false :off} warn-mode)
+      (when-let [s (error-message warning-type extra)]
+        (cond
+          (#{true :warning} warn-mode)
+          #?(:clj  (binding [*out* *err*]
+                     (println (message env (str "WARNING: " s))))
+             :cljs (binding [*print-fn* *print-err-fn*]
+                     (println (message env (str "WARNING: " s)))))
+          (= :error warn-mode)
+          (throw (ex-info s {})))))))
 
 (def ^:dynamic *cljs-warning-handlers*
   [default-warning-handler])

--- a/src/main/clojure/cljs/closure.clj
+++ b/src/main/clojure/cljs/closure.clj
@@ -3048,15 +3048,18 @@
                    ana/*load-tests* (not= (:load-tests opts) false)
                    ana/*cljs-warnings*
                    (let [warnings (opts :warnings true)]
-                     (merge
-                       ana/*cljs-warnings*
-                       (if (or (true? warnings)
-                               (false? warnings))
+                     (cond
+                       (map? warnings)
+                       (merge ana/*cljs-warnings* warnings)
+                       
+                       ;; backwards compatible
+                       (or (boolean? warnings)
+                           (keyword? warnings))
+                       (merge ana/*cljs-warnings*
                          (zipmap
                            [:unprovided :undeclared-var
                             :undeclared-ns :undeclared-ns-form]
-                           (repeat warnings))
-                         warnings)))
+                           (repeat warnings)))))
                    ana/*verbose* (:verbose opts)]
            (when (and ana/*verbose* (not (::watch-triggered-build? opts)))
              (util/debug-prn "Options passed to ClojureScript compiler:" (pr-str opts)))


### PR DESCRIPTION
- matches `:closure-warnings`
- simpler path to fail builds w/o custom error handler